### PR TITLE
implement: missing .nav-links from main theme

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -63,6 +63,24 @@ h2 {
     }
 }
 
+
+.nav-links {
+        a,
+        .dropdown-wrapper .dropdown-title,
+        .dropdown-wrapper .nav-dropdown .dropdown-item a {
+            color: inherit;
+
+            &:hover,
+            &.router-link-active {
+                color: $accentColor;
+            }
+        }
+
+        .dropdown-wrapper .nav-dropdown .dropdown-item a.router-link-active::after {
+            border-left-color: $accentColor;
+        }
+    }
+
 // @searchbox
 .navbar .search-box input {
     &:focus {
@@ -167,7 +185,7 @@ a.sidebar-link {
         }
 
         .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
-            box-shadow: inset 0 -2px 0 0 rgba(#3eaf7c, 0.8);
+            box-shadow: inset 0 -2px 0 0 rgba($accentColor, 0.8);
         }
     }
 }


### PR DESCRIPTION
**Why**

Currently, on small, likely mobile screens, the sidebar navigation has in correctly colored nav links.


<img width="264" alt="image" src="https://user-images.githubusercontent.com/32599364/80780041-80e45380-8b3b-11ea-932f-6b63fee6a384.png">


**Solution**
Implement the missing CSS rules

fixes #8 