### PR TITLE
Fix missing "Python" link value

### DIFF
--- a/docs/guide/getting-started/basic-concepts.md
+++ b/docs/guide/getting-started/basic-concepts.md
@@ -126,6 +126,8 @@ via an Application Programming Interface (API)
 that programmers can interact with using
 the [Python programming language][Python].
 
+[Python]: https://www.python.org/
+
 
 ### The Console
 


### PR DESCRIPTION
I found a broken link or a formatting error which is supposed to be a link to Python's site but seems to just expose the markdown syntax as plain text:

![IMG_20200505_015911](https://user-images.githubusercontent.com/13286080/81021556-13eef780-8e74-11ea-9e24-e0f5ae8715d5.jpg)