### PR TITLE
Update docs according to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,80 +1,61 @@
 # Contribution Guidelines
 
-
 ## Issue
 
-Even though it's very unlikely,
-please search through the existing issues
-and look for existing similar ones
-before submitting your own.
-
+Even though it's very unlikely, please search through the existing issues and
+look for existing similar ones before submitting your own.
 
 ## Pull request
 
-Please try to group related changes into single pull requests
-and create additional ones if necessary.
-This will make reviewing and merging
-much easier and faster.
-
+Please try to group related changes into single pull requests and create
+additional ones if necessary.
+This will make reviewing and merging much easier and faster.
 
 ## Markup Style guidelines
 
 This project uses Markdown as its markup language.
 
-Not all the files in this project
-follow these guidelines yet,
-as we established them
-after a large portion of this guide had been written already.
-If you find any style inconsistencies,
-please file a report or send a pull request to fix them.
+Not all the files in this project follow these guidelines yet, as we established
+them after a large portion of this guide had been written already.
+If you find any style inconsistencies, please file a report or send a pull
+request to fix them.
 
-When changing a file to use semantic linefeeds,
-please apply this in a separate commit
-and do not perform any other content changes
-in the same commit.
-
+When changing a file to use semantic linefeeds, please apply this in a separate
+commit and do not perform any other content changes in the same commit.
 
 ### Markdown Parser
 
-The markup parser is [markdown-it][],
-which can be extended by plugins
-and is furthermore accompanied
-by some of [Vuepress's custom extensions][vuepress-exts].
-You can find the list of plugins we use
-in the `markdown.plugins` list in `config.js`.
+The markup parser is [markdown-it][], which can be extended by plugins and is
+furthermore accompanied by some of
+[Vuepress's custom extensions][vuepress-exts].
+You can find the list of plugins we use in the `markdown.plugins` list in
+`config.js`.
 
 [markdown-it]: https://github.com/markdown-it/markdown-it
 [vuepress-exts]: https://vuepress.vuejs.org/guide/markdown.html
 
-Keywords in upper case
-follow the meanings specified in [RFC-2119][].
+Keywords in upper case follow the meanings specified in [RFC-2119][].
 
 [RFC-2119]: https://tools.ietf.org/html/rfc2119
 
-
 ### Line Widths
 
-Lines MUST NOT be longer than 80 characters,
-except for tables, urls and code blocks.
+Lines MUST NOT be longer than 80 characters, except for tables, urls and code
+blocks.
 
 Split text using [semantic linefeeds][].
-Using those,
-you will hardly ever come near 80 characters
-on a single line.
-Even when you do,
-you should be able to add line breaks
-at fitting locations trivially.
+Using those, you will hardly ever come near 80 characters on a single line.
+Even when you do, you should be able to add line breaks at fitting locations
+trivially.
 This file can serve as an example.
 
 [semantic linefeeds]: https://rhodesmill.org/brandon/2012/one-sentence-per-line/
 
-
 ### Whitespace
 
-Blocks SHOULD be indented by 2 spaces,
-but visual indentation is preferred.
-Inline code should be using code fences,
-especially when syntax highlighting is desired.
+Blocks SHOULD be indented by 2 spaces, but visual indentation is preferred.
+Inline code should be using code fences, especially when syntax highlighting is
+desired.
 
 *Example:*
 
@@ -91,21 +72,18 @@ especially when syntax highlighting is desired.
 ```
 
 Trailing whitespace SHOULD be avoided.
-Insert manual line breaks using `<br>` tags
-instead of using two trailing spaces.
+Insert manual line breaks using `<br>` tags instead of using two trailing
+spaces.
 
-Headings MUST be preceded by two blank lines,
-unless they directly follow another heading
-or the beginning of the file.
+Headings MUST be preceded by two blank lines, unless they directly follow
+another heading or the beginning of the file.
 
-Enumeration and code blocks
-SHOULD be surrounded by blank lines.
-
+Enumeration and code blocks SHOULD be surrounded by blank lines.
 
 ### Enumerations
 
-Enumeration lists MUST begin on the same indentation level
-as their surrounding text.
+Enumeration lists MUST begin on the same indentation level as their surrounding
+text.
 
 - Unnumbered lists SHOULD use the following hierarchy:
 
@@ -125,23 +103,16 @@ as their surrounding text.
      without worrying about numbering.
   ```
 
-
 ### Hyperlinks
 
-Hyperlinks SHOULD NOT be inlined
-and instead use deferred definitions.
+Hyperlinks SHOULD NOT be inlined and instead use deferred definitions.
 The linked text SHOULD NOT be "here".
-Instead, describe what the target page
-covers, represents, or can otherwise be summarized as
-and add the reference to the describing text.
-Use a descriptive shorthand
-if the linked text does not speak for itself.
+Instead, describe what the target page covers, represents, or can otherwise be
+summarized as and add the reference to the describing text.
+Use a descriptive shorthand if the linked text does not speak for itself.
 
-Hyperlink definitions can be placed
-after a paragraph,
-at the end of the section,
-or at the end of the document –
-whatever seems more appropriate.
+Hyperlink definitions can be placed after a paragraph, at the end of the
+section, or at the end of the document – whatever seems more appropriate.
 
 *Example:*
 
@@ -154,33 +125,23 @@ can be found [on Wikipedia][wiki-text].
 [wiki-text]: https://en.wikipedia.org/wiki/Text
 ```
 
-For relative links,
-follow the Vuepress recommendation
-of referencing the files with their `.md` extensions.
-Use absolute paths when linking
-between the guide and the reference sections.
-If the relative URL is short,
-you MAY directly specify the target URL in text.
-
+For relative links, follow the Vuepress recommendation of referencing the files
+with their `.md` extensions.
+Use absolute paths when linking between the guide and the reference sections.
+If the relative URL is short, you MAY directly specify the target URL in text.
 
 ### Headings
 
-The page's title is specified in YAML front matter
-and is inserted into the rendered as a heading of level one.
-Any subsequent headings of the file
-MUST NOT be of heading level two or lower
-(where lower refers to the significance,
-not the numeric value).
+The page's title is specified in YAML front matter and is inserted into the
+rendered as a heading of level one.
+Any subsequent headings of the file MUST NOT be of heading level two or lower
+(where lower refers to the significance, not the numeric value).
 
-Each heading SHOULD be
-under a heading with one level higher.
+Each heading SHOULD be under a heading with one level higher.
 
 Thus, the first markdown heading of the
-The following heading styles
-MUST be used in the displayed order
-for technical reasons
-(e.g. h3 must come after h2 or higher,
-and **not** after h1).
+The following heading styles MUST be used in the displayed order for technical
+reasons (e.g. h3 must come after h2 or higher, and **not** after h1).
 
 *Example:*
 
@@ -205,29 +166,23 @@ With text
 
 ### File Paths
 
-File paths (relative or absolute)
-MUST be specified like this:
+File paths (relative or absolute) MUST be specified like this:
 
     `Packages/SomePackage/somefile.ext`
 
-All paths MUST be written with forward slashes
-unless they are meant to be used in Windows.
+All paths MUST be written with forward slashes unless they are meant to be used
+in Windows.
 
-File extensions (when referring to file types)
-MUST be written like this:
+File extensions (when referring to file types) MUST be written like this:
 
     `.ext`
 
-
 ### Shortcut Keys
 
-All key bindings SHOULD be written
-using our custom Key component.
-The Key chord in the `k` property
-uses the same formatting
-as for Sublime Text keymaps.
-You MAY use `command` and `option`
-for macOS-specific bindings.
+All key bindings SHOULD be written using our custom Key component.
+The Key chord in the `k` property uses the same formatting as for Sublime Text
+keymaps.
+You MAY use `command` and `option` for macOS-specific bindings.
 
 ```html
 <Key k="ctrl+t" /> <!-- single-chord -->
@@ -235,33 +190,28 @@ for macOS-specific bindings.
 <Key k="option+command+up" /> <!-- uses macOS-specific modifiers -->
 ```
 
-Unless otherwise denoted,
-all key bindings MUST refer
-to the default for Windows.
-
+Unless otherwise denoted, all key bindings MUST refer to the default for
+Windows.
 
 ### Sublime Text-specific
 
-- Command captions in the command palette
-  MUST be written as follows:
+- Command captions in the command palette MUST be written as follows:
 
   ```md
   **Preferences: Settings - User**
   ```
 
-- Menu item captions (from the main menu by default)
-  MUST be written as follows (notice the `→`):
+- Menu item captions (from the main menu by default) MUST be written as follows
+  (notice the `→`):
 
   ```md
   *Preferences → Package Settings → ...*
   ```
 
-
 ### Comments
 
-The following comment 'keywords' may be used
-*at the beginning* of a comment
-to mark a section for review:
+The following comment 'keywords' may be used *at the beginning* of a comment to
+mark a section for review:
 
 - XXX
 - TODO

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,1 +1,7 @@
-<a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/88x31.png" /></a><br /><span xmlns:dct="https://purl.org/dc/terms/" href="https://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Sublime Text Unofficial Documentation</span> by <a xmlns:cc="https://creativecommons.org/ns#" href="https://sublimetext.io" property="cc:attributionName" rel="cc:attributionURL">Sublime Text Community</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.<br />Based on a work at <a xmlns:dct="https://purl.org/dc/terms/" href="https://sublimetext.io" rel="dct:source">sublimetext.io</a>.
+<a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">
+    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/88x31.png" />
+</a>
+<br/>
+<span xmlns:dct="https://purl.org/dc/terms/" href="https://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Sublime Text Unofficial Documentation</span> by <a xmlns:cc="https://creativecommons.org/ns#" href="https://sublimetext.io" property="cc:attributionName" rel="cc:attributionURL">Sublime Text Community</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.
+<br />
+Based on a work at <a xmlns:dct="https://purl.org/dc/terms/" href="https://sublimetext.io" rel="dct:source">sublimetext.io</a>.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,34 +1,31 @@
 ---
 terms:
   buffer: >
-    Data of a loaded file and additional metadata,
-    associated with one or more views.
-    The distinction between buffer and :view: is technical.
-    Most of the time,
-    both terms can be used interchangeably.
+    Data of a loaded file and additional metadata, associated with one or more
+    views. The distinction between buffer and :view: is technical. Most of the
+    time, both terms can be used interchangeably.
 
-  view: Graphical display of a buffer. Multiple views can show the same buffer.
+  view: >
+    Graphical display of a buffer.
+    Multiple views can show the same buffer.
 
   plugin: >
-    A feature implemented in Python,
-    which can consist of a single command or multiple commands.
-    It can be contained in one or many .py files.
+    A feature implemented in Python, which can consist of a single command or
+    multiple commands.
+    It can be contained in one or many `.py` files.
 
   panel: >
-    An input/output widget,
-    such as a search panel or output panel.
+    An input/output widget, such as a search panel or output panel.
 
   overlay: >
     An input widget of a special kind.
-    For example, Goto Anything is an overlay.
+    For example, *Goto Anything* is an overlay.
 
   package: >
-    A group of resource files
-    providing extended functionality,
-    consisting of e.g.
-    snippets, syntax definitions, or plugins.
-    Can be a folder in the Packages folder
-    or an archived .sublime-package file.
+    A group of resource files providing extended functionality, consisting of
+    e.g. snippets, syntax definitions, or plugins.
+    Can be a folder in the Packages folder or an archived `.sublime-package`
+    file.
 
   user package: >
     A :package: installed or managed by the user.
@@ -37,48 +34,43 @@ terms:
     A :package: that is provided by Sublime Text on every installation.
 
   core package: >
-    A :shipped_package:
-    that provides core functionality for Sublime Text.
+    A :shipped_package: that provides core functionality for Sublime Text.
 
   installed package: >
-    A :user_package: inside the Installed Packages folder
-    in the .sublime-package archive format.
+    A :user_package: inside the `Installed Packages` folder in the
+    `.sublime-package` archive format.
 
   override package: >
-    A special package
-    that can override individual resource files
-    of an :installed_package: or :shipped_package:.
+    A special package that can override individual resource files of an
+    :installed_package: or :shipped_package:.
 
   file type: >
-    In the context of Sublime Text,
-    a file type refers to the type of file
-    as determined by the applicable .sublime-syntax syntax definition.
-    However, this is an ambiguous term
-    and in some instances it could also be used
-    with the broader meaning it has in technical texts.
+    In the context of Sublime Text, a file type refers to the type of file as
+    determined by the applicable `.sublime-syntax` syntax definition.
+    However, this is an ambiguous term and in some instances it could also be
+    used with the broader meaning it has in technical texts.
 
   PackageDev: >
-    An installable package that provides
-    syntax highlighting, snippets, completions, and more
-    for Sublime Text's resource files.
+    An installable :package: that provides syntax highlighting, snippets,
+    completions, and more for Sublime Text's resource files.
 
   Package Control: >
-    The de-facto package manager for Sublime Text. 
+    The de-facto package manager for Sublime Text.
     <a href="https://packagecontrol.io/">https://packagecontrol.io/</a>
 
   command: >
-    A command is an action to be executed
-    and can be referenced in many resource files.
-    It may accept JSON-serializable arguments
-    and can be defined in user plugins.
+    A command is an action to be executed and can be referenced in many resource
+    files.
+    It may accept JSON-serializable arguments and can be defined in user
+    plugins.
 
   Data directory: >
     Core concept and storage for all of Sublime Text's resources.
     Refer to the introduction for details.
 
   console: >
-    Internal Sublime Text console for debug messages
-    and plugin output. Open via *View → Show Console*.
+    Internal Sublime Text console for debug messages and plugin output.
+    Open via *View → Show Console*.
 ---
 
 <Glossary :terms="$frontmatter.terms" />

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,18 +5,16 @@ actionText: Open Guide
 actionLink: guide/
 # TODO add links to reference
 ---
-The Sublime Text Community Documentation 
-is a community effort 
-at documenting the [Sublime Text][] text editor
-and accompanying its [official documentation][].
+The Sublime Text Community Documentation is a community effort at documenting
+the [Sublime Text][] text editor and accompanying its
+[official documentation][].
 
 [Sublime Text]: https://sublimetext.com/
-[official documentation]: https://sublimetext.com/docs/3/
+[official documentation]: https://sublimetext.com/docs/
 
 ::: tip Notice
 This documentation is currently undergoing updates and modifications.
 :::
-
 
 ## Layout
 
@@ -24,17 +22,15 @@ The documentation is split into two sections:
 
 1. [**The Guide**](/guide/).
 
-   Includes basic information on Sublime Text,
-   covers its usage
-   and how it can be customized.
+   Includes basic information on Sublime Text, covers its usage and how it can
+   be customized.
 
 2. [**The Reference**](/reference/).
    *(For experienced users.)*
 
-   This is where you can look up
-   (almost) all the details you need to know
-   about how to structure your custom key bindings
-   or how to disable a menu item for your plugin.
+   This is where you can look up (almost) all the details you need to know about
+   how to structure your custom key bindings or how to disable a menu item for
+   your plugin.
 
 <!-- TODO mention FAQ, once filled -->
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,12 +1,27 @@
 {
+  "name": "docs.sublimetext.io",
   "private": true,
+  "description": "Sublime Text Community Documentation",
+  "homepage": "https://docs.sublimetext.io",
+  "bugs": {
+    "url": "https://github.com/sublimetext-io/docs.sublimetext.io/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sublimetext-io/docs.sublimetext.io.git"
+  },
   "license": "MIT",
   "scripts": {
-    "serve": "vuepress dev .",
-    "build": "vuepress build ."
+    "serve": "yarn install && vuepress dev .",
+    "build": "yarn install && vuepress build ."
+  },
+  "engines": {
+    "node": ">= 14.1.0",
+    "npm": ">= 6.14.5",
+    "yarn": ">= 1.22.4"
   },
   "devDependencies": {
-    "@vuepress/plugin-google-analytics": "^1.2.0",
-    "vuepress": "^1.2.0"
+    "@vuepress/plugin-google-analytics": "^1.4.1",
+    "vuepress": "^1.4.1"
   }
 }

--- a/docs/reference/color_schemes_legacy.md
+++ b/docs/reference/color_schemes_legacy.md
@@ -95,10 +95,6 @@ Most elements controlling colors accept an alpha channel value:
   Container for further color scheme settings.
   See [Sub-elements of Settings][] for details.
 
-<!--
-  FIXME: UUIDs can be referenced by *.py files, are otherwise redundant, though.
--->
-
 `uuid`
 : **Optional.**
   A unique identifier for the file.

--- a/docs/reference/color_schemes_legacy.md
+++ b/docs/reference/color_schemes_legacy.md
@@ -2,43 +2,33 @@
 title: Color Schemes (Legacy)
 ---
 
-Color schemes define the colors
-used to highlight source code in Sublime Text views
-and to style different elements
-found in the editing area:
+Color schemes define the colors used to highlight source code in Sublime Text
+views and to style different elements found in the editing area:
 background, foreground, selection, caret...
 
 
 ::: warning
-This document describes
-the old `.tmTheme` color scheme (not theme!) format
+This document describes the old `.tmTheme` color scheme (not theme!) format
 inherited from TextMate.
 
-For the new `.sublime-color-scheme` format
-added in Sublime Text 3.1,
+For the new `.sublime-color-scheme` format, added in Sublime Text 3.1,
 refer to the [official documentation][].
 :::
 
 [official documentation]: https://www.sublimetext.com/docs/3/color_schemes.html
 
 ::: tip Note
-Sublime Text differentiates
-between "color schemes" defining colors in the editor area
-and "themes" defining the layout for the rest of the UI.
-Rather confusingly,
-the *color scheme* format inherited from TextMate
-uses the `.tmTheme` unchanged extension,
-because themes in TextMate themes
-are what color schemes are for Sublime Text.
+Sublime Text differentiates between **Color Schemes** defining colors in the
+editor area and **Themes** defining the layout for the rest of the UI.
+Rather confusingly, the *color scheme* format inherited from TextMate uses the
+`.tmTheme` unchanged extension, because themes in TextMate themes are what color
+schemes are for Sublime Text.
 
-It's important to remember
-that UI themes and color schemes
-are two different customization mechanisms.
-Generally speaking, it is far less complex
-to create a new color scheme
-than it is to create a new UI theme.
+It's important to remember that UI themes and color schemes are two different
+customization mechanisms.
+Generally speaking, it is far less complex to create a new color scheme than it
+is to create a new UI theme.
 :::
-
 
 ##  File Format
 
@@ -49,39 +39,30 @@ than it is to create a new UI theme.
 | **Name**      | Any                                       |
 | **Location**  | Any under `Packages`                      |
 
-The file format of color scheme files
-is inherited from Textmate.
-
+The file format of color scheme files is inherited from Textmate.
 
 ##  Where to Store Color Schemes
 
-By convention,
-[packages][] primarily containing
-a set of color scheme files
+By convention, [packages][] primarily containing a set of color scheme files
 have the *Color Scheme -* prefix.
 For example: *Color Scheme - Default*.
 
-The file names of all available color schemes
-are displayed in the **Preferences → Color Scheme** menu,
-grouped by the containing package.
+The file names of all available color schemes are displayed in the
+**Preferences → Color Scheme** menu, grouped by the containing package.
 
 [packages]: /guide/extensibility/packages.md
 
 ## Structure of a Color Scheme File
 
-All color scheme files share
-the same topmost structure.
+All color scheme files share the same topmost structure.
 
-Colors can be expressed in the
-following formats:
+Colors can be expressed in the following formats:
 `#RRGGBB`, `#RGB`, [X11 color names][]
 
 [X11 color names]: https://en.wikipedia.org/wiki/X11_color_names
 
-Most elements controlling colors
-accept an alpha channel value:
+Most elements controlling colors accept an alpha channel value:
 `#RRGGBBAA`.
-
 
 ## Root Elements in Color Schemes Files
 
@@ -102,6 +83,8 @@ accept an alpha channel value:
 </plist>
 ```
 
+<!-- TODO: DOCTYPE line is ignored by Sublime Text -->
+
 `name`
 : **Optional.**
   Name of the color scheme.
@@ -112,6 +95,10 @@ accept an alpha channel value:
   Container for further color scheme settings.
   See [Sub-elements of Settings][] for details.
 
+<!--
+  FIXME: UUIDs can be referenced by *.py files, are otherwise redundant, though.
+-->
+
 `uuid`
 : **Optional.**
   A unique identifier for the file.
@@ -119,24 +106,18 @@ accept an alpha channel value:
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
 
-
-
 [Sub-elements of Settings]: #sub-elements-of-settings
 
 ## Sub-elements of Settings
 
-Sublime Text supports
-the following color scheme settings:
-
+Sublime Text supports the following color scheme settings:
 
 ### Global Settings
 
 Not associated with any scope.
-These settings affect global visual items
-in the editing area.
+These settings affect global visual items in the editing area.
 
-Global settings go inside a `<dict>` element
-within the topmost `<array>`.
+Global settings go inside a `<dict>` element within the topmost `<array>`.
 
 ```xml
 <array>
@@ -160,9 +141,8 @@ within the topmost `<array>`.
 : Default foreground color for the view.
   Affects file contents, the gutter, rulers and guides.
   The alpha channel does not apply to file contents.
-  Because there is no override setting for rulers,
-  the only way to change the color of rulers
-  is a "hack" further described [on CursorRuler's wiki][hack].
+  Because there is no override setting for rulers, the only way to change the
+  color of rulers is a "hack" further described [on CursorRuler's wiki][hack].
 
   [hack]: https://github.com/icylace/CursorRuler/wiki/Tips#ruler-colors
 
@@ -181,19 +161,16 @@ within the topmost `<array>`.
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
 
-
 #### Brackets
 
 `bracketContentsOptions`
-: Controls how brackets are highlighted
-  when a caret is between a bracket pair.
+: Controls how brackets are highlighted when a caret is between a bracket pair.
   Expects a space-separated list of the available options.
 
-  Only applied when the `match_brackets` setting
-  is set to `true`.
+  Only applied when the `match_brackets` setting is set to `true`.
 
-  Options: `underline`, `stippled_underline`, `squiggly_underline`,
-  `foreground`
+  Options:
+  `underline`, `stippled_underline`, `squiggly_underline`, `foreground`
 
   **Default:** `underline`
 
@@ -201,52 +178,41 @@ within the topmost `<array>`.
 : Color of the highlighting(s)
   selected by `bracketContentsOptions`.
 
-  Only applied when the `match_brackets` setting
-  is set to `true`.
+  Only applied when the `match_brackets` setting is set to `true`.
 
 `bracketsOptions`
-: Controls how brackets are highlighted
-  when a caret is next to a bracket.
+: Controls how brackets are highlighted when a caret is next to a bracket.
   Expects a space-separated list of the available options.
 
-  Only applied when the `match_brackets` setting
-  is set to `true`.
+  Only applied when the `match_brackets` setting is set to `true`.
 
-  Options: `underline`, `stippled_underline`, `squiggly_underline`,
-  `foreground`
+  Options:
+  `underline`, `stippled_underline`, `squiggly_underline`, `foreground`
 
   **Default:** `underline`
 
 `bracketsForeground`
-: Color of the highlighting(s)
-  selected by `bracketOptions`.
+: Color of the highlighting(s) selected by `bracketOptions`.
 
-  Only applied when the `match_brackets` setting
-  is set to `true`.
-
+  Only applied when the `match_brackets` setting is set to `true`.
 
 #### Tags
 
 `tagsOptions`
-: Controls how tags are highlighted
-  when a caret is inside a tag.
+: Controls how tags are highlighted when a caret is inside a tag.
   Expects a space-separated list of the available options.
 
-  Only applied when the `match_tags` setting
-  is set to `true`.
+  Only applied when the `match_tags` setting is set to `true`.
 
-  Options: `underline`, `stippled_underline`, `squiggly_underline`,
-  `foreground`
+  Options:
+  `underline`, `stippled_underline`, `squiggly_underline`, `foreground`
 
   **Default:** `stippled_underline`
 
 `tagsForeground`
-: Color of the highlighting(s)
-  selected by `tagsOptions`.
+: Color of the highlighting(s) selected by `tagsOptions`.
 
-  Only applied when the `match_tags` setting
-  is set to `true`.
-
+  Only applied when the `match_tags` setting is set to `true`.
 
 #### Find
 
@@ -258,7 +224,6 @@ within the topmost `<array>`.
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
 
-
 #### Gutter
 
 `gutter`
@@ -268,7 +233,6 @@ within the topmost `<array>`.
 : Foreground color of the gutter.
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
-
 
 #### Selection
 
@@ -283,42 +247,36 @@ within the topmost `<array>`.
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
 
-
 #### Guides
 
 `guide`
 : Color of the guides displayed to indicate nesting levels.
 
-  Only used if the `indent_guide_options` setting
-  includes`draw_normal`.
+  Only used if the `indent_guide_options` setting includes`draw_normal`.
 
 `activeGuide`
 : Color of the guide lined up with the caret.
 
-  Only applied if the `indent_guide_options` setting
-  includes `draw_active`.
+  Only applied if the `indent_guide_options` setting includes `draw_active`.
 
 `stackGuide`
 : Color of the current guide's parent guide levels.
 
-  Only used if the `indent_guide_options` setting
-  is set to `draw_active`.
+  Only used if the `indent_guide_options` setting is set to `draw_active`.
 
 <!-- TODO image -->
-
 
 #### Highlighted Regions
 
 `highlight`
-: Background color for regions added via `sublime.add_regions()`
-with the `sublime.DRAW_OUTLINED` flag added.
+: Background color for regions added via `sublime.add_regions()` with the
+`sublime.DRAW_OUTLINED` flag added.
 
 `highlightForeground`
-: Foreground color for regions added via `sublime.add_regions()`
-  with the `sublime.DRAW_OUTLINED` flag added.
+: Foreground color for regions added via `sublime.add_regions()` with the
+`sublime.DRAW_OUTLINED` flag added.
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
-
 
 #### Shadow
 
@@ -328,13 +286,10 @@ with the `sublime.DRAW_OUTLINED` flag added.
 `shadowWidth`
 : Width of the shadow effect when the buffer is scrolled.
 
-  Values greater than 32
-  cause the shadow to be hidden.
-  The default is 8.
+  Values greater than `32` cause the shadow to be hidden.
+  The **default** is `8`.
 
-  Note that, despite its nature,
-  this expects a **string value**.
-
+  Note that, despite its nature, this expects a **string value**.
 
 ### Scoped Settings
 
@@ -367,12 +322,12 @@ Settings associated with a particular scope.
 `settings`
 : Container for settings.
   Valid settings are:
-  
-  `fontStyle`
-  : Space-separated list of
-    styles for the font.
 
-    Options: `bold`, `italic`, nothing (resets fontStyle to normal)
+  `fontStyle`
+  : Space-separated list of styles for the font.
+
+    Options:
+    `bold`, `italic`, nothing (resets fontStyle to normal)
 
   `foreground`
   : Foreground color.
@@ -380,23 +335,19 @@ Settings associated with a particular scope.
   `background`
   : Background color.
 
-
 ##  Minimal Scope Coverage
 
-Refer to the [official Scope Naming guidelines]
-in order to find out
-which scopes a color scheme should cover at minimum.
+Refer to the [official Scope Naming guidelines][] in order to find out which
+scopes a color scheme should cover at minimum.
 
 [official Scope Naming guidelines]: http://www.sublimetext.com/docs/3/scope_naming.html#color_schemes
-
 
 ##  Sublime Text Settings Related to Color Schemes
 
 ### View Settings
 
 `color_scheme`
-: Path to a color scheme file
-  relative to the Data folder
+: Path to a color scheme file relative to the Data folder
   (example: `Packages/Color Scheme - Default/Monokai.tmTheme`).
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->

--- a/docs/reference/command_palette.md
+++ b/docs/reference/command_palette.md
@@ -4,17 +4,24 @@ title: Command Palette
 
 The command palette is fed entries with `.sublime-commands` files.
 
-
 ## File Format
 
 Here's an excerpt from `Packages/Default/Default.sublime-commands`:
 
 ```json
 [
-    { "caption": "Project: Save As", "command": "save_project_and_workspace_as" },
-    { "caption": "Project: Close", "command": "close_workspace" },
-    { "caption": "Project: Add Folder", "command": "prompt_add_folder" },
-
+    {
+        "caption": "Project: Save As",
+        "command": "save_project_and_workspace_as"
+    },
+    {
+        "caption": "Project: Close",
+        "command": "close_workspace"
+    },
+    {
+        "caption": "Project: Add Folder",
+        "command": "prompt_add_folder"
+    },
     {
         "caption": "Preferences: Settings",
         "command": "edit_settings", "args":
@@ -23,12 +30,38 @@ Here's an excerpt from `Packages/Default/Default.sublime-commands`:
             "default": "// Settings in here override those in \"Default/Preferences.sublime-settings\",\n// and are overridden in turn by syntax-specific settings.\n{\n\t$0\n}\n"
         }
     },
-
-    { "caption": "Preferences: Browse Packages", "command": "open_dir", "args": {"dir": "$packages"} },
-
-    { "caption": "Permute Lines: Reverse", "command": "permute_lines", "args": {"operation": "reverse"} },
-    { "caption": "Permute Lines: Unique", "command": "permute_lines", "args": {"operation": "unique"} },
-    { "caption": "Permute Lines: Shuffle", "command": "permute_lines", "args": {"operation": "shuffle"} },
+    {
+        "caption": "Preferences: Browse Packages",
+        "command": "open_dir",
+        "args":
+        {
+            "dir": "$packages"
+        }
+    },
+    {
+        "caption": "Permute Lines: Reverse",
+        "command": "permute_lines",
+        "args":
+        {
+            "operation": "reverse"
+        }
+    },
+    {
+        "caption": "Permute Lines: Unique",
+        "command": "permute_lines",
+        "args":
+        {
+            "operation": "unique"
+        }
+    },
+    {
+        "caption": "Permute Lines: Shuffle",
+        "command": "permute_lines",
+        "args":
+        {
+            "operation": "shuffle"
+        }
+    },
 ]
 ```
 
@@ -39,11 +72,10 @@ Here's an excerpt from `Packages/Default/Default.sublime-commands`:
 : Command to be executed.
 
 `args`
-: Arguments to pass to `command`. 
+: Arguments to pass to `command`.
 
-  Note that the special snippet-like variable `${packages}`
-  is only interpreted by certain :command:commands:.
-
+  Note that the special snippet-like variable `${packages}` is only interpreted
+  by certain :command:commands:.
 
 ## How to Use the Command Palette
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -9,27 +9,25 @@ This list of commands is a work in progress.
 <!-- TODO Remove after full ReST to MD Conversion
 - .. _cmd-about-paths: -->
 
-
 ## About Paths in Command Arguments
 [About Paths in Command Arguments]: #about-paths-in-command-arguments
 
-Some commands take paths as parameters. Among these, some support snippet-like
-syntax, while others don't. A command of the first kind would take a parameter
-like `${packages}/SomeDir/SomeFile.ext` whereas a command of the second kind
-would take a parameter like `Packages/SomeDir/SomeFile.ext`.
+Some commands take paths as parameters.
+Among these, some support snippet-like syntax, while others don't.
+A command of the first kind would take a parameter like
+`${packages}/SomeDir/SomeFile.ext` whereas a command of the second kind would
+take a parameter like `Packages/SomeDir/SomeFile.ext`.
 
 Generally, newer commands support the snippet-like syntax.
 
-Commands expect UNIX-style paths if not otherwise noted, including on
-Windows (for example, `/c/Program Files/Sublime Text 3/sublime_plugin.py`).
+Commands expect UNIX-style paths if not otherwise noted, including on Windows
+(for example, `/c/Program Files/Sublime Text 3/sublime_plugin.py`).
 
 Often, relative paths in arguments to commands are assumed to start at the
 :Data_directory:.
 
-
 <!--  TODO: split into Window and Text (and Application) commands since they behave
 - differently and require other call mechanisms when called from a plugin -->
-
 
 ## Commands
 
@@ -40,9 +38,9 @@ Often, relative paths in arguments to commands are assumed to start at the
 `set_build_system`
 : Changes the current build system.
 
-  - **file** (String): Path to the build system. If empty, Sublime Text tries
-    to automatically find an appropriate build systems from specified
-    selectors.
+  - **file** (String): Path to the build system.
+    If empty, Sublime Text tries to automatically find an appropriate build
+    systems from specified selectors.
   - **index** (Int): Used in the **Tools | Build System** menu but otherwise
     probably not useful.
 
@@ -52,7 +50,6 @@ Often, relative paths in arguments to commands are assumed to start at the
 `toggle_save_all_on_build`
 : Toggles whether all open files should be saved before starting the build.
 
-
 `run_macro_file`
 : Runs a *.sublime-macro* file.
 
@@ -61,8 +58,9 @@ Often, relative paths in arguments to commands are assumed to start at the
 `insert_snippet`
 : Inserts a snippet from a string or *.sublime-snippet* file.
 
-  - **contents** (String): Snippet as a string to be inserted. Remember that
-    backslashes `\` have to be escaped, like in every other JSON string.
+  - **contents** (String): Snippet as a string to be inserted.
+    Remember that backslashes `\` have to be escaped, like in every other JSON
+    string.
   - **name** (String): [Relative path][About Paths in Command Arguments] to the
     *.sublime-snippet* file to be inserted.
 
@@ -88,8 +86,9 @@ Often, relative paths in arguments to commands are assumed to start at the
 `move`
 : Advances the caret by predefined units.
 
-  - **by** (Enum): Values: *characters*, *words*, *word_ends*, *subwords*,
-      *subword_ends*, *lines*, *pages*, *stops*.
+  - **by** (Enum): Values:
+    *characters*, *words*, *word_ends*, *subwords*, *subword_ends*, *lines*,
+    *pages*, *stops*.
   - **forward** (Bool): Whether to advance or reverse in the buffer.
   - **word_begin** (Bool)
   - **empty_line** (Bool)
@@ -100,24 +99,27 @@ Often, relative paths in arguments to commands are assumed to start at the
 `move_to`
 : Advances the caret to predefined locations.
 
-  - **to** (Enum): Values: *bol*, *eol*, *bof*, *eof*, *brackets*.
-  - **extend** (Bool): Whether to extend the selection. Defaults to `false`.
+  - **to** (Enum): Values:
+    *bol*, *eol*, *bof*, *eof*, *brackets*.
+  - **extend** (Bool): Whether to extend the selection.
+    Defaults to `false`.
 
 `open_file`
 : Opens the specified file.
-  Will dynamically open resource files
-  from [sublime-package archives][] as read-only
-  if the specified *override file* does not exist.
+  Will dynamically open resource files from [sublime-package archives][] as
+  read-only if the specified *override file* does not exist.
 
   - **file** (String): [Absolute or relative path][About Paths in Command Arguments]
-    to the file to be opened. Relative paths will originate from the recently
+    to the file to be opened.
+    Relative paths will originate from the recently
 
     Expands snippet-like variables, such as `$platform` and `$packages`.
 
-  - **contents** (String): This string will be written to the new buffer if
-    the file does not exist. accessed directory (e.g. the directory of the currently opened file).
+  - **contents** (String):
+    This string will be written to the new buffer if the file does not exist.
+    Accessed directory (e.g. the directory of the currently opened file).
 
-    .. XXX more variables?
+    <!-- XXX more variables? -->
 
 `open_dir`
 : Opens the specified directory with the default file manager.
@@ -136,15 +138,15 @@ Often, relative paths in arguments to commands are assumed to start at the
 `switch_file`
 : Switches between two files with the same name and different extensions.
 
-  - **extensions** (String): Extensions (without leading dot) for which
-    switching will be enabled.
+  - **extensions** (String):
+    Extensions (without leading dot) for which switching will be enabled.
 
 `close`
 : Closes the active view.
 
 `close_file`
-: Closes the active view and, under certain circumsances, the whole
-  application.
+: Closes the active view and, under certain circumsances, the whole application.
+
 <!--   XXX Sounds kinda wrong. -->
 
 `exit`
@@ -230,8 +232,8 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Redoes each action stepping through granular edits.
 
 `cut`
-: Removes the selected text and sends it to the system clipboard. Put
-  differently, it cuts.
+: Removes the selected text and sends it to the system clipboard.
+  Put differently, it cuts.
 
 `copy`
 : Sends the selected text to to the system clipboard.
@@ -239,8 +241,8 @@ Often, relative paths in arguments to commands are assumed to start at the
 `paste`
 : Inserts the clipboard contents after the caret.
 
-  - **clipboard** (String): May be *selection*. XXX what other values are
-    allowed?
+  - **clipboard** (String): May be *selection*.
+    <!-- XXX what other values are allowed? -->
 
 `paste_and_indent`
 : Inserts the clipboard contents after the caret and indents contextually.
@@ -248,14 +250,14 @@ Often, relative paths in arguments to commands are assumed to start at the
 `select_lines`
 : Adds a line to the current selection.
 
-  - **forward** (Bool): Whether to add the next or previous line. Defaults to
-    `true`.
+  - **forward** (Bool): Whether to add the next or previous line.
+    Defaults to `true`.
 
 `scroll_lines`
 : Scrolls lines in the view.
 
-  **amount** \[Float\]\: Positive values scroll lines down and negative values
-  scroll lines up.
+  **amount** \[Float\]\:
+  Positive values scroll lines down and negative values scroll lines up.
 
 `prev_view`
 : Switches to the previous view.
@@ -286,8 +288,9 @@ Often, relative paths in arguments to commands are assumed to start at the
 `hide_panel`
 : Hides the active panel.
 
-  - **cancel** (Bool): Notifies the panel to restore the selection to what it
-    was when the panel was opened. (Only incremental find panel.)
+  - **cancel** (Bool):
+    Notifies the panel to restore the selection to what it was when the panel
+    was opened. (Only incremental find panel.)
 
 `hide_overlay`
 : Hides the active overlay. Show the overlay using the show_overlay command.
@@ -297,17 +300,18 @@ Often, relative paths in arguments to commands are assumed to start at the
 
 `insert_best_completion`
 : Inserts the best completion that can be inferred from the current context.
-<!-- TODO Probably useless. XXX -->
+<!-- TODO Probably useless. -->
 
   - **default** (String): String to insert failing a best completion.
 
 `replace_completion_with_next_completion`
-  <!-- TODO Useless for users. XXX -->
+  <!-- TODO Useless for users. -->
 
 `reindent`
 : Corrects indentation of the selection with regular expressions set in the
-  syntax's preferences. The base indentation will be that of the line before
-  the first selected line. Sometimes does not work as expected.
+  syntax's preferences.
+  The base indentation will be that of the line before the first selected line.
+  Sometimes does not work as expected.
 
 `indent`
 : Increments indentation of selection.
@@ -329,7 +333,7 @@ Often, relative paths in arguments to commands are assumed to start at the
 `commit_completion`
 : Inserts into the buffer the item that's currently selected in the auto
   complete list.
-<!-- TODO Probably not useful for users. XXX -->
+<!-- TODO Probably not useful for users. -->
 
 `toggle_overwrite`
 : Toggles overwriting on or off.
@@ -337,8 +341,9 @@ Often, relative paths in arguments to commands are assumed to start at the
 `expand_selection`
 : Extends the selection up to predefined limits.
 
-  - **to** (Enum): Values: *bol*, *hardbol*, *eol*, *hardeol*, *bof*, *eof*,
-    *brackets*, *line*, *tag*, *scope*, *indentation*.
+  - **to** (Enum): Values:
+    *bol*, *hardbol*, *eol*, *hardeol*, *bof*, *eof*, *brackets*, *line*, *tag*,
+    *scope*, *indentation*.
 
 `close_tag`
 : Surrounds the current inner text with the appropiate tags.
@@ -353,7 +358,7 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Prompts for a file path to save the macro in the macro buffer to.
 
 `show_overlay`
-: Shows the requested overlay. Use the #### hide_overlay command to hide it.
+: Shows the requested overlay. Use the `hide_overlay` command to hide it.
 
   - **overlay** (Enum):
     The type of overlay to show. Possible values:
@@ -361,16 +366,18 @@ Often, relative paths in arguments to commands are assumed to start at the
     - *goto*: Show the [Goto Anything][] overlay.
     - *command_palette*: Show the [Command Palette][].
 
-  - **show_files** (Bool): If using the goto overlay, start by displaying
-    files rather than an empty widget.
-  - **text** (String): The initial contents to put in the overlay.
-
+  - **show_files** (Bool):
+    If using the goto overlay, start by displaying files rather than an empty
+    widget.
+  - **text** (String):
+    The initial contents to put in the overlay.
 
 `show_panel`
 : Shows a panel.
 
-  - **panel** (Enum): Values: *incremental_find*, *find*, *replace*,
-    *find_in_files*, *console* or *output.\<panel_name\>*.
+  - **panel** (Enum): Values:
+    *incremental_find*, *find*, *replace*, *find_in_files*, *console* or
+    *output.\<panel_name\>*.
   - **reverse** (Bool): Whether to search backwards in the buffer.
   - **toggle** (Bool): Whether to hide the panel if it's already visible.
 
@@ -381,12 +388,12 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Finds the previous occurrence of the current search term.
 
 `find_under_expand`
-: Adds a new selection based on the current selection or expands the
-  selection to the current word.
+: Adds a new selection based on the current selection or expands the selection
+  to the current word.
 
 `find_under_expand_skip`
-: Adds a new selection based on the current selection or expands the
-  selection to the current word while removing the current selection.
+: Adds a new selection based on the current selection or expands the selection
+  to the current word while removing the current selection.
 
 `find_under`
 : Finds the next occurrence of the current selection or the current word.
@@ -398,12 +405,11 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Finds all occurrences of the current selection or the current word.
 
 `slurp_find_string`
-: Copies the current selection or word into the "find" field of the find
-  panel.
+: Copies the current selection or word into the "find" field of the find panel.
 
 `slurp_replace_string`
-: Copies the current selection or word into the "replace" field of the find
-  and replace panel.
+: Copies the current selection or word into the "replace" field of the find and
+  replace panel.
 
 `next_result`
 : Advance to the next captured result.
@@ -412,15 +418,20 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Move to the previous captured result.
 
 `toggle_setting`
-: Toggles the value of a boolean setting. This value is view-specific.
+: Toggles the value of a boolean setting.
+  This value is view-specific.
 
-  - **setting** (String): The name of the setting to be toggled.
+  - **setting** (String):
+    The name of the setting to be toggled.
 
 `set_setting`
-: Set the value of a setting. This value is view-specific.
+: Set the value of a setting.
+  This value is view-specific.
 
-  - **setting** (String): The name of the setting to changed.
-  - **value** (\*): The value to set to.
+  - **setting** (String):
+    The name of the setting to changed.
+  - **value** (\*):
+    The value to set to.
 
 `set_line_ending`
 : Changes the line endings of the current file.
@@ -442,7 +453,8 @@ Often, relative paths in arguments to commands are assumed to start at the
 `toggle_comment`
 : Comments or uncomments the active lines, if available.
 
-  - **block** (Bool): Whether to insert a block comment.
+  - **block** (Bool):
+    Whether to insert a block comment.
 
 `join_lines`
 : Joins the current line with the next one.
@@ -456,31 +468,34 @@ Often, relative paths in arguments to commands are assumed to start at the
 `replace_completion_with_auto_complete`
 : XXX
 
+<!-- TODO: fix above -->
+
 `show_scope_name`
 : Shows the name for the caret's scope in the status bar.
-
 
 `exec`
 : Runs an external process asynchronously. On Windows, GUIs are supressed.
 
   `exec` is the default command used by build systems, thus it provides
-  similar functionality. However, a few options in build systems are taken
-  care of by Sublime Text internally so they list below only contains
-  parameters accepted by this command.
+  similar functionality.
+  However, a few options in build systems are taken care of by Sublime Text
+  internally so they list below only contains parameters accepted by this
+  command.
 
   - **cmd** [(String)]
-  - **shell_cmd** (String): Shell command to use. If given overrides
-    `cmd` and ignores `shell`.
+  - **shell_cmd** (String): Shell command to use.
+    If given overrides `cmd` and ignores `shell`.
   - **file_regex** (String)
   - **line_regex** (String)
   - **working_dir** (String)
   - **encoding** (String)
   - **env** [{String: String}]
-  - **quiet** (Bool): If `True` no runtime information is printed if the
-    command fails or has a non-zero exit code.
-  - **kill** (Bool): If `True` will simply terminate the current build
-    process. This is invoked via *Build: Cancel* command from the
-    [Command Palette][].
+  - **quiet** (Bool):
+    If `True` no runtime information is printed if the command fails or has a
+    non-zero exit code.
+  - **kill** (Bool):
+    If `True` will simply terminate the current build process.
+    This is invoked via *Build: Cancel* command from the [Command Palette][].
   - **update_phantoms_only** (Bool)
   - **hide_phantoms_only** (Bool)
   - **word_wrap** (Bool): Whether to word-wrap the output in the build panel
@@ -498,43 +513,53 @@ Often, relative paths in arguments to commands are assumed to start at the
 
   With selection: The contents of the selected regions are circulated.
   Without selection: Swaps adjacent characters and moves the caret forward by
-  1.
+  `1`.
 
 `sort_lines`
 : Sorts lines.
 
-  - **case_sensitive** (Bool): Whether the sort should be case sensitive.
+  - **case_sensitive** (Bool):
+    Whether the sort should be case sensitive.
 
 `sort_selection`
 : Sorts lines in selection.
 
-  - **case_sensitive** (Bool): Whether the sort should be case sensitive.
+  - **case_sensitive** (Bool):
+    Whether the sort should be case sensitive.
 
 `permute_lines`
 : XXX
+
+<!-- TODO: fix above -->
 
   - **operation** (Enum): *reverse*, *unique*, *shuffle* ...?
 
 `permute_selection`
 : XXX
 
+<!-- TODO: fix above -->
+
   - **operation** (Enum): *reverse*, *unique*, *shuffle* ...?
 
 `set_layout`
-: Changes the group layout of the current window. This command uses the same
-  pattern as [`Window.set_layout`][], see there for a list and
-  explanation of parameters.
+: Changes the group layout of the current window.
+  This command uses the same pattern as [`Window.set_layout`][], see there for a
+  list and explanation of parameters.
 
 `focus_group`
 : Gives focus to the top-most file in the specified group.
 
-  - **group** (Int): The group index to focus. This is determined by the order
-    of `cells` items from the current layout (see [`Window.set_layout`][]).
+  - **group** (Int):
+    The group index to focus.
+    This is determined by the order of `cells` items from the current layout
+    (see [`Window.set_layout`][]).
 
 `move_to_group`
 : Moves the current file to the specified group.
 
-  - **group** (Int): The group index to focus. See #### focus_group command.
+  - **group** (Int):
+    The group index to focus.
+    See `focus_group` command.
 
 `select_by_index`
 : Focuses a certain tab in the current group.
@@ -548,8 +573,9 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Select the previous bookmarked region.
 
 `toggle_bookmark`
-: Sets or unsets a bookmark for the active region(s). (Bookmarks can be
-  accessed via the regions API using `"bookmarks"` as the key.)
+: Sets or unsets a bookmark for the active region(s).
+  (Bookmarks can be accessed via the regions API using `"bookmarks"` as the
+  key.)
 
 `select_bookmark`
 : Selects a bookmarked region in the current file.
@@ -563,7 +589,8 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Selects all bookmarked regions.
 
 `wrap_lines`
-: Wraps lines. By default, it wraps lines at the first ruler's column.
+: Wraps lines.
+  By default, it wraps lines at the first ruler's column.
 
   - **width** (Int): Specifies the column at which lines should be wrapped.
 
@@ -581,24 +608,26 @@ Often, relative paths in arguments to commands are assumed to start at the
 : Swaps the case of each character in the selection.
 
 `set_mark`
-: Marks the position of each caret in the current file. If any marks have
-  already been set in that file, they are removed.
+: Marks the position of each caret in the current file.
+  If any marks have already been set in that file, they are removed.
 
 `select_to_mark`
 : Selects the text between the current position of each one of the current
-  carets and the marked position. Each caret is matched with each mark
-  in order of occurrence, and is moved to the beginning of its selection.
+  carets and the marked position.
+  Each caret is matched with each mark in order of occurrence, and is moved to
+  the beginning of its selection.
 
-  If any number of selections overlap, they are joined and, of all the
-  carets corresponding to each one of the joined selections, only the one
-  occurring first in the file is preserved.
+  If any number of selections overlap, they are joined and, of all the carets
+  corresponding to each one of the joined selections, only the one occurring
+  first in the file is preserved.
 
-  If the number of current carets is less or equal to the number of marks,
-  the remaining marks in order are ignored. Conversely, if currently there
-  are more carets than marks, the first relevant selections are produced.
-  Of all extra marks, those contained in the selections are removed, and
-  the rest of them are left where they are, without triggering a selection
-  from their position.
+  If the number of current carets is less or equal to the number of marks, the
+  remaining marks in order are ignored.
+  Conversely, if currently there are more carets than marks, the first relevant
+  selections are produced.
+  Of all extra marks, those contained in the selections are removed, and the
+  rest of them are left where they are, without triggering a selection from
+  their position.
 
 `delete_to_mark`
 : Deletes the text that `select_to_mark` would select.
@@ -609,14 +638,16 @@ Often, relative paths in arguments to commands are assumed to start at the
 
 `clear_bookmarks`
 : If no **name** argument, or the **name** "bookmarks" is specified, it
-   removes all bookmarks set in the current file, but not the marks. If
-   the **name** "mark" is specified as an argument, it removes all marks set
+   removes all bookmarks set in the current file, but not the marks.
+   If the **name** "mark" is specified as an argument, it removes all marks set
    in the current file, but not the bookmarks.
 
   - **name** (String): e.g. `"mark"`, `"bookmarks"`.
 
 `yank`
 : XXX
+
+<!-- TODO: fix above -->
 
 `show_at_center`
 : Scrolls the view to show the selected line in the middle of the view and
@@ -631,12 +662,13 @@ Often, relative paths in arguments to commands are assumed to start at the
 `reset_font_size`
 : Resets the font size to the default
 
-  *Note*: This essentially removes the entry from your User settings, there
-  might be other places where this has been "changed".
+  *Note*:
+  This essentially removes the entry from your `User` settings, there might be
+  other places where this has been "changed".
 
 `fold`
-: Folds the current selection and displays ``…`` instead. Unfold arrows are
-  added to the lines where a region has been folded.
+: Folds the current selection and displays ``…`` instead.
+  Unfold arrows are added to the lines where a region has been folded.
 
 `unfold`
 : Unfolds all folded regions in the selection or the current line if there is
@@ -644,12 +676,14 @@ Often, relative paths in arguments to commands are assumed to start at the
 
 `fold_by_level`
 : Scans the whole file and folds everything with an indentation level of
-  `level` or higher. This does not unfold already folded regions if you first
-  fold by level 2 and then by 3, for example. Sections with cursors are not
-  folded.
+  `level` or higher.
+  This does not unfold already folded regions if you first fold by level 2 and
+  then by 3, for example.
+  Sections with cursors are not folded.
 
-  - **level** (Int): The level of indentation that should be folded. `0` is
-    equivalent to running #### unfold_all.
+  - **level** (Int):
+    The level of indentation that should be folded.
+    `0` is equivalent to running `unfold_all`.
 
 `fold_tag_attributes`
   Folds all tag attributes in XML files, only leaving the tag's name and the
@@ -685,12 +719,13 @@ Often, relative paths in arguments to commands are assumed to start at the
 `reopen`
 : Reopens the current file.
 
-  - **encoding** (String): The file encoding the file should be reopened with.
+  - **encoding** (String):
+    The file encoding the file should be reopened with.
 
 `clone_file`
-: Clones the current view into the same tab group, both sharing the same
-  buffer. That means you can drag one tab to another group and every update to
-  one view will be visible in the other one too.
+: Clones the current view into the same tab group, both sharing the same buffer.
+  That means you can drag one tab to another group and every update to one view
+  will be visible in the other one too.
 
 `revert`
 : Undoes all unsaved changes to the file.
@@ -698,10 +733,14 @@ Often, relative paths in arguments to commands are assumed to start at the
 `expand_tabs`
 : XXX
 
+<!-- TODO: fix above -->
+
   - **set_translate_tabs** (Bool)
 
 `unexpand_tabs`
 : XXX
+
+<!-- TODO: fix above -->
 
   - **set_translate_tabs** (Bool)
 
@@ -719,9 +758,10 @@ Often, relative paths in arguments to commands are assumed to start at the
 `show_about_window`
 : I think you know what this does.
 
-<!-- Some regex-related and search-related commands missing. They don't seem to
-be too useful. -->
-
+<!--
+  TODO: Some regex-related and search-related commands missing.
+        They don't seem to be too useful.
+-->
 
 ## Discovering Commands
 
@@ -730,29 +770,31 @@ binding, in a macro, as a menu entry or in a plugin.
 
 - Browsing the default key bindings at **Preferences | Key Bindings - Default**.
   If you know the key binding whose command you want to inspect, you can just
-  search for it using the [search panel][]. This, of course, also works in the
-  opposite direction.
+  search for it using the [search panel][].
+  This, of course, also works in the opposite direction.
 
 [search panel]: /guide/search-and-replace/single.md
 
 - `sublime.log_commands(True)`
 
-  Running the above in the :console: will tell Sublime Text to print the command's
-  name in the console whenever a command is run. You can practically just enter
-  this, do whatever is needed to run the command you want to inspect and then
-  look at the console. It will also print the passed arguments so you can
-  basically get all the information you need from it. When you are done, just
-  run the function again with `False` as parameter.
+  Running the above in the :console: will tell Sublime Text to print the
+  command's name in the console whenever a command is run.
+  You can practically just enter this, do whatever is needed to run the command
+  you want to inspect and then look at the console.
+  It will also print the passed arguments so you can basically get all the
+  information you need from it.
+  When you are done, just run the function again with `False` as parameter.
 
-- Inspecting `.sublime-menu` files. If your command is run by a menu item,
-  browse the default menu file at `Packages/Default/Main.sublime-menu`.
-  You will find them quick enough once you take a look at it, or see the [menu documentation][].
+- Inspecting `.sublime-menu` files.
+  If your command is run by a menu item, browse the default menu file at
+  `Packages/Default/Main.sublime-menu`.
+  You will find them quick enough once you take a look at it, or see the
+  [menu documentation][].
 
 [menu documentation]: ./menus.md
 
 - Similar to menus, you can do exactly the same with `.sublime-command` files.
-  See [completions][] for some documentation on completion
-  files.
+  See [completions][] for some documentation on completion files.
 
 [completions]: ./completions.md
 [Goto Anything]: /guide/file-management/navigation.md#goto-anything

--- a/docs/reference/comments.md
+++ b/docs/reference/comments.md
@@ -2,39 +2,32 @@
 title: Comments
 ---
 
-Sublime Text provides a default command
-to comment and uncomment lines of code.
-This command can be enabled
-for any type of file using metadata files.
+Sublime Text provides a default command to comment and uncomment lines of code.
+This command can be enabled for any type of file using metadata files.
 
 
 ## File Format
 
 Comment markers are defined using metadata files.
-However, because metadata for comment markers
-is commonly required by packages,
-it's discussed separately in this page
-for convenience.
+However, because metadata for comment markers is commonly required by packages,
+it's discussed separately in this page for convenience.
 
-Just as regular metadata files,
-comment metadata files
-have the `.tmPreferences` extension
-and use the Property List format.
+Just as regular metadata files, comment metadata files have the `.tmPreferences`
+extension and use the Property List format.
 The file name is ignored by Sublime Text.
+
+<!-- TODO: add plist link -->
 
 ::: seealso
 [Metadata](./metadata.md) Detailed documentation on metadata.
 :::
 
-
 ## Example
 
-Let's see a basic example
-of a comment metadata file:
+Let's see a basic example of a comment metadata file:
 
 ```xml {12,16,18}
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
    <key>name</key>
@@ -57,20 +50,16 @@ of a comment metadata file:
 </dict>
 </plist>
 ```
-In the example we've highlighted
-some parts that are specific
-to comment metadata files.
 
+In the example we've highlighted some parts that are specific to comment metadata files.
 
 ## Structure of a Comment Metadata File
 
-All comment metadata files
-share the same topmost structure,
+All comment metadata files share the same topmost structure,
 which is inherited from Property List format:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
    ...
@@ -78,8 +67,7 @@ which is inherited from Property List format:
 </plist>
 ```
 
-These are all the valid elements
-in a comment metadata file:
+These are all the valid elements in a comment metadata file:
 
 `name`
 : **Optional.**
@@ -93,12 +81,10 @@ in a comment metadata file:
 
 `scope`
 : **Required.**
-  Comma-separated list of scope selectors
-  to determine in which context the metadata
-  should be active.
+  Comma-separated list of scope selectors to determine in which context the
+  metadata should be active.
 
-  In most cases you'll use
-  the base scope for a particular syntax.
+  In most cases you'll use the base scope for a particular syntax.
 
   ```xml
   <key>scope</key>
@@ -121,6 +107,12 @@ in a comment metadata file:
   A unique identifier for the file.
   Ignored by Sublime Text.
 
+  <!--
+    FIXME: This is not true.
+           UUIDs can be referenced by py package files, and consequently used.
+           Otherwise redundant, though.
+  -->
+
   ```xml
   <key>uuid</key>
   <string>BC062860-3346-4D3B-8421-C5543F83D11F</string>
@@ -142,10 +134,8 @@ in a comment metadata file:
 ## `shellVariables` Subelements
 
 ::: tip Note
-The `shellVariables` array
-may contain any arbitrary subelement,
-but here we're only concerned
-with those related to comments.
+The `shellVariables` array may contain any arbitrary subelement, but here we're
+only concerned with those related to comments.
 See [Shell Variables][] for details.
 :::
 
@@ -155,8 +145,8 @@ See [Shell Variables][] for details.
 : **Required.**
   Defines a default comment marker.
 
-  To define additional comment markers,
-  name them `TM_COMMENT_START_2`, `TM_COMMENT_START_3`, etc.
+  To define additional comment markers, name them `TM_COMMENT_START_2`,
+  `TM_COMMENT_START_3`, etc.
 
   ```xml
   <dict>
@@ -173,13 +163,11 @@ See [Shell Variables][] for details.
   If omitted,
   `TM_COMMENT_START` will be treated as a line comment marker.
 
-  If present
-  and a corresponding start comment marker
-  can be found,
+  If present and a corresponding start comment marker can be found,
   the pair is treated as block comment markers.
 
-  To define additional end comment markers,
-  name them `TM_COMMENT_END_2`, `TM_COMMENT_END_3`, etc.
+  To define additional end comment markers, name them `TM_COMMENT_END_2`,
+  `TM_COMMENT_END_3`, etc.
 
   ```xml
   <dict>
@@ -193,11 +181,9 @@ See [Shell Variables][] for details.
 `TM_COMMENT_DISABLE_INDENT`
 : **Optional.**
   Valid values are `yes` and `no`.
-  Disables indentation for the `TM_COMMENT_START`
-  marker.
+  Disables indentation for the `TM_COMMENT_START` marker.
 
-  To target other group of markers,
-  use `TM_COMMENT_DISABLE_INDENT_2`, etc.
+  To target other group of markers, use `TM_COMMENT_DISABLE_INDENT_2`, etc.
 
   ```xml
   <dict>
@@ -210,13 +196,11 @@ See [Shell Variables][] for details.
 
 ## Example
 
-Here's a more complete example
-of a comment metadata file
-using some of the features just discussed:
+Here's a more complete example of a comment metadata file using some of the
+features just discussed:
 
 ```xml {15,21}
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
    <dict>
       <key>shellVariables</key>
@@ -247,9 +231,8 @@ using some of the features just discussed:
 
 ## Related Keyboard Shortcuts
 
-Once comment metadata has been defined,
-you can use standard key bindings
-to comment and uncomment lines of code.
+Once comment metadata has been defined, you can use standard key bindings to
+comment and uncomment lines of code.
 
 | Description          | Shortcut                 |
 | -------------------- | ------------------------ |

--- a/docs/reference/completions.md
+++ b/docs/reference/completions.md
@@ -7,25 +7,18 @@ title: Completions Files
 : Introduction to the different types of completions
 :::
 
-Completions aren't limited to completions files,
-because other sources contribute
-to the completions list
-(see above).
-However, the most explicit way
-Sublime Text provides you to feed it completions
+Completions aren't limited to completions files, because other sources
+contribute to the completions list (see above).
+However, the most explicit way Sublime Text provides you to feed it completions
 is by means of `.sublime-completions` files.
 
-This topic only deals with
-the format of a `.sublime-completions` file.
-
+This topic only deals with the format of a `.sublime-completions` file.
 
 ## File Format
 
-Completions are JSON files
-with the `.sublime-completions` extension.
-Entries in completions files can contain
-either snippet-like strings or plain text.
-
+Completions are JSON files with the `.sublime-completions` extension.
+Entries in completions files can contain either snippet-like strings or plain
+text.
 
 ### Example
 
@@ -33,76 +26,84 @@ Here's an example (with HTML completions):
 
 ```json
 {
-   "scope": "text.html - source - meta.tag, punctuation.definition.tag.begin",
-
-   "completions":
-   [
-      { "trigger": "a", "contents": "<a href=\"$1\">$0</a>" },
-      { "trigger": "abbr\t<abbr>", "contents": "<abbr>$0</abbr>" },
-      { "trigger": "acronym", "contents": "<acronym>$0</acronym>" }
-   ]
+    "scope": "text.html - source - meta.tag, punctuation.definition.tag.begin",
+    "completions":
+    [
+        {
+            "trigger": "a",
+            "contents": "<a href=\"$1\">$0</a>"
+        },
+        {
+            "trigger": "abbr\t<abbr>",
+            "contents": "<abbr>$0</abbr>"
+        },
+        {
+            "trigger": "acronym",
+            "contents": "<acronym>$0</acronym>"
+        }
+    ]
 }
 ```
 
 **scope**
-: Determines when the completions list
-  will be populated with this list of completions.
+: Determines when the completions list will be populated with this list of
+  completions.
 
   See [Scopes][] for more information.
 
-[Scopes]: /guide/extensibility/syntaxdefs.md#scopes 
+[Scopes]: /guide/extensibility/syntaxdefs.md#scopes
 
 **completions**
 : Array of *completions*.
 
-  <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
-
+  <!-- TODO: Cause upper text to become a paragraph and fix a spacing bug. -->
 
 ## Types of Completions
 
 ### Plain Strings
 
-Plain strings are equivalent to
-an entry where the `trigger`
-is identical to the `contents`:
+Plain strings are equivalent to an entry where the `trigger` is identical to the
+`contents`:
 
 ```json
 "foo"
 // is equivalent to:
-{ "trigger": "foo", "contents": "foo" }
+{
+    "trigger": "foo",
+    "contents": "foo"
+}
 ```
-
 
 ### Trigger-based Completions
 
 ```json
-{ "trigger": "foo", "contents": "foobar" },
-{ "trigger": "foo\ttest", "contents": "foobar" }
+{
+    "trigger": "foo",
+    "contents": "foobar"
+},
+{   "trigger": "foo\ttest",
+    "contents": "foobar"
+}
 ```
 
 **trigger**
-: Text that will be displayed in the completions list
-  and will cause the `contents`
-  to be inserted when chosen.
+: Text that will be displayed in the completions list and will cause the
+  `contents` to be inserted when chosen.
 
-  You can use a `\t` tab character
-  to add an *annotation* for the preceding trigger.
-  The annotation will be displayed right-aligned,
-  slightly grayed
-  and does not affect the trigger itself.
+  You can use a `\t` tab character to add an *annotation* for the preceding
+  trigger.
+  The annotation will be displayed right-aligned, slightly grayed and does not
+  affect the trigger itself.
 
 **contents**
 : Text to be inserted in the buffer.
-  Supports the same string interpolation features
-  as snippets.
+  Supports the same string interpolation features as snippets.
 
   Refer to [Snippet Features][].
 
 [Snippet Features]: /guide/extensibility/snippets.md#snippet-features
 
 ::: tip
-If you want a literal `$`,
-you have to escape it like this: `\\$`
-(double backslashes are needed
-because we are within a JSON string).
+If you want a literal `$`, you have to escape it like this: `\\$`
+(double backslashes are needed because we are within a JSON string).
 :::

--- a/docs/reference/key_bindings.md
+++ b/docs/reference/key_bindings.md
@@ -35,8 +35,11 @@ These are all valid elements in a key binding:
 `keys`
 : An array of case-sensitive keys.
   Modifiers can be specified with the `+` sign.
-  You can build chords by adding elements to the array
-  (for example, `["ctrl+k","ctrl+j"]`).
+  You can build chords by adding elements to the array.
+  For example:
+  ```json
+  [ "ctrl+k", "ctrl+j" ]
+  ```
   Ambiguous chords are resolved with a timeout.
 
 `command`

--- a/docs/reference/key_bindings.md
+++ b/docs/reference/key_bindings.md
@@ -8,29 +8,24 @@ Key bindings map key presses to commands.
 [Official documentation for Key Bindings](https://www.sublimetext.com/docs/3/key_bindings.html)
 :::
 
-
 ## File Format
 
-Key bindings are stored in `.sublime-keymap` files
-and defined in JSON.
+Key bindings are stored in `.sublime-keymap` files and defined in JSON.
 Keymap files may be located anywhere in a package.
-
 
 ### Naming Keymap Files
 
-Any keymap named `Default.sublime-keymap`
-will always be applied in all platforms.
+Any keymap named `Default.sublime-keymap` will always be applied in all
+platforms.
 
-Additionally, each platform
-can optionally have its own keymap:
+Additionally, each platform can optionally have its own keymap:
 
 - `Default (Windows).sublime-keymap`
 - `Default (OSX).sublime-keymap`
 - `Default (Linux).sublime-keymap`
 
-Sublime Text will ignore any `.sublime-keymap` file
-whose name doesn't follow the patterns just described.
-
+Sublime Text will ignore any `.sublime-keymap` file whose name doesn't follow
+the patterns just described.
 
 ### Structure of a Key Binding
 
@@ -39,93 +34,101 @@ These are all valid elements in a key binding:
 
 `keys`
 : An array of case-sensitive keys.
-  Modifiers can be specified
-  with the `+` sign.
-  You can build chords
-  by adding elements to the array
+  Modifiers can be specified with the `+` sign.
+  You can build chords by adding elements to the array
   (for example, `["ctrl+k","ctrl+j"]`).
-  Ambiguous chords are resolved
-  with a timeout.
+  Ambiguous chords are resolved with a timeout.
 
 `command`
 : Name of the command to be executed.
 
 `args`
-: Dictionary of arguments
-  to be passed to `command`.
-  Keys must be names
-  of parameters to `command`.
+: Dictionary of arguments to be passed to `command`.
+  Keys must be names of parameters to `command`.
 
 `context`
-: Array of conditions
-  that determine a particular *context*.
-  All conditions must evaluate to `true`
-  for the context to be active.
-  See [Structure of a Context][] below
-  for more information.
+: Array of conditions that determine a particular *context*.
+  All conditions must evaluate to `true` for the context to be active.
+  See [Structure of a Context][] below for more information.
 
-  <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
-
+  <!-- TODO: Cause upper text to become a paragraph and fix a spacing bug. -->
 
 Here's an example:
 
 ```json
-{ "keys": ["shift+enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"}, "context":
-   [
-      { "key": "setting.auto_indent", "operator": "equal", "operand": true },
-      { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "\\{$", "match_all": true },
-      { "key": "following_text", "operator": "regex_contains", "operand": "^\\}", "match_all": true }
-   ]
+{
+    "keys":
+    [
+        "shift+enter"
+    ],
+    "command": "insert_snippet",
+    "args":
+    {
+        "contents": "\n\t$0\n"
+    },
+    "context":
+    [
+        {
+            "key": "setting.auto_indent",
+            "operator": "equal",
+            "operand": true
+        },
+        {
+            "key": "selection_empty",
+            "operator": "equal",
+            "operand": true,
+            "match_all": true
+        },
+        {
+            "key": "preceding_text",
+            "operator": "regex_contains",
+            "operand": "\\{$",
+            "match_all": true
+        },
+        {
+            "key": "following_text",
+            "operator": "regex_contains",
+            "operand": "^\\}",
+            "match_all": true
+        }
+    ]
 }
 ```
-
 
 [Structure of a Context]: #structure-of-a-context
 
 ### Structure of a Context
 
 `key`
-: Name of the context
-  whose value you want to query.
+: Name of the context whose value you want to query.
 
 `operator`
 : Type of test to perform against `key`'s value.
   Defaults to `equal`.
 
 `operand`
-: The result returned by `key`
-  is tested against this value.
+: The result returned by `key` is tested against this value.
 
 `match_all`
-: Requires the test to succeed
-  for all selections.
+: Requires the test to succeed for all selections.
   Defaults to `false`.
 
-  <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
-
+  <!-- TODO: Cause upper text to become a paragraph and fix a spacing bug. -->
 
 #### Context Keys
 
 Arbitrary keys may be provided by plugins.
-Thus, this section only features keys
-provided by Sublime Text itself.
+Thus, this section only features keys provided by Sublime Text itself.
 
 `auto_complete_visible`
-: Returns `true`
-  if the autocomplete list
-  is visible.
+: Returns `true` if the autocomplete list is visible.
 
 `has_next_field`
-: Returns `true`
-  if a next snippet field
-  is available.
+: Returns `true` if a next snippet field is available.
 
 `has_prev_field`
-: Returns `true`
-  if a previous snippet field
-  is available.
-   
+: Returns `true` if a previous snippet field is available.
+
 `last_command`
 : Returns the name of the last command run.
 
@@ -133,49 +136,40 @@ provided by Sublime Text itself.
 : Returns the number of selections.
 
 `overlay_visible`
-: Returns `true`
-  if any overlay is visible.
+: Returns `true` if any overlay is visible.
 
 `panel_visible`
-: Returns `true`
-  if any panel is visible.
+: Returns `true` if any panel is visible.
 
 `following_text`
-: Test against the selected text and the text
-  following it until the end of the line.
+: Test against the selected text and the text following it until the end of the
+  line.
 
 `preceding_text`
-: Test against the text on the line up to and
-  including the selection.
+: Test against the text on the line up to and including the selection.
 
 `selection_empty`
-: Returns `true`
-  if the selection
-  is an empty region.
+: Returns `true` if the selection is an empty region.
 
 `setting.x`
 : Returns the value of the `x` setting.
   `x` can be any string.
 
 `text`
-: Restricts the test
-  to the selected text.
+: Restricts the test to the selected text.
 
 `selector`
 : Returns the name of the current scope.
 
 `panel_has_focus`
-: Returns `true`
-  if a panel
-  has input focus.
+: Returns `true` if a panel has input focus.
 
 `panel`
-: Returns `true`
-  if the panel given as `operand`
-  is visible.
+: Returns `true` if the panel given as `operand` is visible.
 
-  <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
-
+  <!--
+    TODO: Cause upper text to become a paragraph and fix a spacing bug.
+  -->
 
 #### Context Operators
 
@@ -187,20 +181,17 @@ provided by Sublime Text itself.
 
 `regex_contains`, `not_regex_contains`
 : Match against a regular expression (partial match).
-  
-  <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
 
+  <!--
+    TODO: Cause upper text to become a paragraph and fix a spacing bug.
+  -->
 
 ## Bindable Keys
 
-Keys in key bindings may be specified
-literally by symbol
-or by a name for a special key.
+Keys in key bindings may be specified literally by symbol or by a name for a special key.
 Symbols cannot be combined with modifiers.
-For example,
-`B` will catch any key sequence inserting a `B` glyph,
-but `ctrl+B` is invalid
-and needs to be written as `ctrl+shift+b` instead.
+For example, `B` will catch any key sequence inserting a `B` glyph, but `ctrl+B`
+is invalid and needs to be written as `ctrl+shift+b` instead.
 
 Here's the list of the names for special keys:
 
@@ -231,7 +222,6 @@ Here's the list of the names for special keys:
 |                | `browser_favorites` | `f23` |
 |                | `browser_home`      | `f24` |
 
-
 ### Modifiers
 
 * `shift`
@@ -242,102 +232,78 @@ Here's the list of the names for special keys:
 * `command` (**MacOS only**)
 * `option` (**MacOS only**: same as `alt`)
 
-
 ### The Any Character Binding
 
-Adding a binding for `<character>`
-(with the angled brackets and no modifiers)
-causes Sublime Text to bind the given command
-for **all** glyphs provided to it.
-You should thus only use this binding
-with an accompanying context filter.
+Adding a binding for `<character>` (with the angled brackets and no modifiers)
+causes Sublime Text to bind the given command for **all** glyphs provided to it.
+You should thus only use this binding with an accompanying context filter.
 
-The specified command will then receive
-an additional `character` argument
+The specified command will then receive an additional `character` argument
 containing the glyph that was captured.
-
 
 ### Warning about Bindable Keys
 
-If you're developing a package,
-keep this in mind:
+If you're developing a package, keep this in mind:
 
-* <kbd>Ctrl+Alt+\<alphanum\></kbd> should never be used in any Windows key bindings.
+* <kbd>Ctrl+Alt+\<alphanum\></kbd> should never be used in any Windows key
+  bindings.
 * <kbd>Option+\<alphanum\></kbd> should never be used in any OS X key bindings.
 
-In both cases,
-the user's ability
-to insert non-ASCII characters
-would be compromised otherwise.
+In both cases, the user's ability to insert non-ASCII characters would be
+compromised otherwise.
 
-End-users are free to remap
-any key combination.
-
+End-users are free to remap any key combination.
 
 ## Command Mode
 
-Sublime Text provides a `command_mode` setting
-to prevent key presses
-from being sent to the buffer.
-This is useful, for example,
-to emulate Vim's modal behavior.
+Sublime Text provides a `command_mode` setting to prevent key presses from being
+sent to the buffer.
+This is useful, for example, to emulate Vim's modal behavior.
 
-Key bindings not intended for command mode
-(generally, all of them)
-should include a context like this:
+Key bindings not intended for command mode (generally, all of them) should
+include a context like this:
 
 ```json
-{"key": "setting.command_mode", "operand": false}
+{
+    "key": "setting.command_mode",
+    "operand": false
+}
 ```
 
-This way, plugins legitimately using command mode
-will be able to define appropriate key bindings
-without interference.
-
+This way, plugins legitimately using command mode will be able to define
+appropriate key bindings without interference.
 
 ## Order of Preference for Key Bindings
 
-Key bindings in a keymap file are evaluated
-from the bottom to the top.
+Key bindings in a keymap file are evaluated from the bottom to the top.
 The first matching context wins.
-
 
 ## Keeping Keymaps Organized
 
-Sublime Text ships with default keymaps
-under `Packages/Default`.
-Other packages may include
-keymap files of their own.
+Sublime Text ships with default keymaps under `Packages/Default`.
+Other packages may include keymap files of their own.
 
-The recommended storage location
-for your personal keymap files is `Packages/User`.
+The recommended storage location for your personal keymap files is
+`Packages/User`.
 
 ::: seealso
 [Merging and Order of Precedence](/guide/extensibility/packages.md#merging-and-order-of-precedence)
 :::
 
-
 ## International Keyboards
 
-Due to the way Sublime Text
-maps key names to physical keys,
-key names may not correspond to
-physical keys in keyboard layouts
-other than US English.
-
+Due to the way Sublime Text maps key names to physical keys, key names may not
+correspond to physical keys in keyboard layouts other than US English.
 
 ## Troubleshooting
 
-To enable logging
-related to keymaps, [see the documentation][api-docs] for:
+To enable logging related to keymaps, [see the documentation][api-docs] for:
 
 - sublime.log_commands(flag)
 - sublime.log_input(flag)
 
 These may help with debugging keymaps.
-When a key chord does not trigger an input log,
-another application or your operating system
-is likely grabbing the key
-before it can reach Sublime Text.
+When a key chord does not trigger an input log, another application or your
+operating system is likely grabbing the key before it can reach Sublime Text.
 
 [api-docs]: https://www.sublimetext.com/docs/3/api_reference.html

--- a/docs/reference/keyboard_shortcuts_osx.md
+++ b/docs/reference/keyboard_shortcuts_osx.md
@@ -13,15 +13,15 @@ This topic is a draft and may contain wrong information.
 | <Key k="command+x" />                    | Cut line                                                                 |
 | <Key k="command+enter" />                | Insert line after                                                        |
 | <Key k="command+shift+enter" />          | Insert line before                                                       |
-| <Key k="command+ctrl+up" />              | Move line/selection up                                                   |
-| <Key k="command+ctrl+down" />            | Move line/selection down                                                 |
+| <Key k="ctrl+command+up" />              | Move line/selection up                                                   |
+| <Key k="ctrl+command+down" />            | Move line/selection down                                                 |
 | <Key k="command+l" />                    | Select line - Repeat to select next lines                                |
 | <Key k="command+d" />                    | Select word - Repeat to select next occurrence                           |
 | <Key k="ctrl+command+g" />               | Select all occurrences of current selection                              |
 | <Key k="ctrl+shift+up" />                | Extra cursor on the line above                                           |
 | <Key k="ctrl+shift+down" />              | Extra cursor on the line below                                           |
 | <Key k="ctrl+m" />                       | Jump to closing parentheses Repeat to jump to opening parentheses        |
-| <Key k="ctrl+shift+m" />                 | Select all contents of the current parentheses                           |
+| <Key k="ctrl+shift+m" />                 | Expand selection to brackets                                             |
 | <Key k="ctrl+a" />                       | Move to beginning of line                                                |
 | <Key k="command+left" />                 | Move to beginning of text on line                                        |
 | <Key k="ctrl+e, command+right" />        | Move to end of line                                                      |
@@ -42,7 +42,6 @@ This topic is a draft and may contain wrong information.
 | <Key k="ctrl+shift+w" />                 | Wrap Selection in html tag                                               |
 | <Key k="ctrl+shift+k" />                 | Delete current line of cursor                                            |
 
-
 ## Navigation/Goto Anywhere
 
 | Keypress                         | Command                   |
@@ -51,7 +50,6 @@ This topic is a draft and may contain wrong information.
 | <Key k="command+r" />            | Goto symbol               |
 |                                  | Goto word in current file |
 | <Key k="ctrl+g" />               | Goto line in current file |
-
 
 ## General
 
@@ -64,7 +62,6 @@ This topic is a draft and may contain wrong information.
 | <Key k="command+k, command+b" /> | Toggle side bar              |
 | <Key k="ctrl+shift+p" />         | Show scope in status bar     |
 
-
 ## Find/Replace
 
 | Keypress                     | Command          |
@@ -73,7 +70,6 @@ This topic is a draft and may contain wrong information.
 | <Key k="command+option+f" /> | Replace          |
 | <Key k="command+shift+f" />  | Find in files    |
 | <Key k="command+i" />        | Incremental Find |
-
 
 ## Scrolling
 
@@ -98,9 +94,7 @@ This topic is a draft and may contain wrong information.
 | <Key k="shift+ctrl+tab" />   | Cycle down through recent tabs    |
 |                              | Find in files                     |
 
-
 ## Split window
-
 
 | Keypress                     | Command                       |
 | ---------------------------- | ----------------------------- |
@@ -112,9 +106,7 @@ This topic is a draft and may contain wrong information.
 | <Key k="ctrl+[1-4]" />       | Jump to group                 |
 | <Key k="ctrl+shift+[1-4]" /> | Move file to specified group  |
 
-
 ## Bookmarks
-
 
 | Keypress                     | Command           |
 | ---------------------------- | ----------------- |
@@ -123,12 +115,10 @@ This topic is a draft and may contain wrong information.
 | <Key k="shift+f2" />         | Previous bookmark |
 | <Key k="shift+command+f2" /> | Clear bookmarks   |
 
-
 ## Text manipulation
 
-
-| Keypress                                         | Command                                       |
-| ------------------------------------------------ | -----------------------------                 |
-| <Key k="command+k, command+u" />                 | Transform to Uppercase                        |
-| <Key k="command+k, command+l" />                 | Transform to Lowercase                        |
-| <Key k="command+ctrl+down, command+ctrl+down" /> | Clip text upwards / downwards                 |
+| Keypress                                         | Command                       |
+| ------------------------------------------------ | ----------------------------- |
+| <Key k="command+k, command+u" />                 | Transform to Uppercase        |
+| <Key k="command+k, command+l" />                 | Transform to Lowercase        |
+| <Key k="ctrl+command+down, ctrl+command+down" /> | Clip text upwards / downwards |

--- a/docs/reference/keyboard_shortcuts_win.md
+++ b/docs/reference/keyboard_shortcuts_win.md
@@ -8,32 +8,32 @@ This topic is a draft and may contain wrong information.
 
 ## Editing
 
-| Keypress                           | Command                                                                                                                                     |
-| ---------------------------------- | ------------------------------------------------------------------------                                                                    |
-| <Key k="ctrl+x" />                 | Cut line                                                                                                                                    |
-| <Key k="ctrl+enter" />             | Insert line after                                                                                                                           |
-| <Key k="ctrl+shift+enter" />       | Insert line before                                                                                                                          |
-| <Key k="ctrl+shift+up" />          | Move line/selection up                                                                                                                      |
-| <Key k="ctrl+shift+down" />        | Move line/selection down                                                                                                                    |
-| <Key k="ctrl+l" />                 | Select line - Repeat to select next lines                                                                                                   |
-| <Key k="ctrl+d" />                 | Select word - Repeat select others occurrences                                                                                              |
-| <Key k="ctrl+m" />                 | Jump to closing parentheses Repeat to jump to opening parentheses                                                                           |
-| <Key k="ctrl+shift+m" />           | Select all contents of the current parentheses                                                                                              |
-| <Key k="ctrl+shift+k" />           | Delete Line                                                                                                                                 |
-| <Key k="ctrl+k, ctrl+k" />         | Delete from cursor to end of line                                                                                                           |
-| <Key k="ctrl+k, ctrl+backspace" /> | Delete from cursor to start of line                                                                                                         |
-| <Key k="ctrl+]" />                 | Indent current line(s)                                                                                                                      |
-| <Key k="ctrl+[" />                 | Un-indent current line(s)                                                                                                                   |
-| <Key k="ctrl+shift+d" />           | Duplicate line(s)                                                                                                                           |
-| <Key k="ctrl+j" />                 | Join line below to the end of the current line                                                                                              |
-| <Key k="ctrl+/" />                 | Comment/un-comment current line                                                                                                             |
-| <Key k="ctrl+shift+/" />           | Block comment current selection                                                                                                             |
-| <Key k="ctrl+y" />                 | Redo, or repeat last keyboard shortcut command                                                                                              |
-| <Key k="ctrl+shift+v" />           | Paste and indent correctly                                                                                                                  |
-| <Key k="ctrl+space" />             | Select next auto-complete suggestion                                                                                                        |
-| <Key k="ctrl+u" />                 | soft undo; jumps to your last change before undoing change when repeated                                                                    |
-| <Key k="alt+shift+w" />            | Wrap Selection in html tag                                                                                                                  |
-| <Key k="alt+." />                  | Close current html tag                                                                                                                      |
+| Keypress                           | Command                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| <Key k="ctrl+x" />                 | Cut line                                                                 |
+| <Key k="ctrl+enter" />             | Insert line after                                                        |
+| <Key k="ctrl+shift+enter" />       | Insert line before                                                       |
+| <Key k="ctrl+shift+up" />          | Move line/selection up                                                   |
+| <Key k="ctrl+shift+down" />        | Move line/selection down                                                 |
+| <Key k="ctrl+l" />                 | Select line - Repeat to select next lines                                |
+| <Key k="ctrl+d" />                 | Select word - Repeat select others occurrences                           |
+| <Key k="ctrl+m" />                 | Jump to closing parentheses Repeat to jump to opening parentheses        |
+| <Key k="ctrl+shift+m" />           | Expand selection to brackets                                             |
+| <Key k="ctrl+shift+k" />           | Delete Line                                                              |
+| <Key k="ctrl+k, ctrl+k" />         | Delete from cursor to end of line                                        |
+| <Key k="ctrl+k, ctrl+backspace" /> | Delete from cursor to start of line                                      |
+| <Key k="ctrl+]" />                 | Indent current line(s)                                                   |
+| <Key k="ctrl+[" />                 | Un-indent current line(s)                                                |
+| <Key k="ctrl+shift+d" />           | Duplicate line(s)                                                        |
+| <Key k="ctrl+j" />                 | Join line below to the end of the current line                           |
+| <Key k="ctrl+/" />                 | Comment/un-comment current line                                          |
+| <Key k="ctrl+shift+/" />           | Block comment current selection                                          |
+| <Key k="ctrl+y" />                 | Redo, or repeat last keyboard shortcut command                           |
+| <Key k="ctrl+shift+v" />           | Paste and indent correctly                                               |
+| <Key k="ctrl+space" />             | Select next auto-complete suggestion                                     |
+| <Key k="ctrl+u" />                 | soft undo; jumps to your last change before undoing change when repeated |
+| <Key k="alt+shift+w" />            | Wrap Selection in html tag                                               |
+| <Key k="alt+." />                  | Close current html tag                                                   |
 
 ## Windows
 

--- a/docs/reference/menus.md
+++ b/docs/reference/menus.md
@@ -7,7 +7,6 @@ title: Menus
 : Explains how menus work and what you can do with them.
 :::
 
-
 ## File Format
 
 | Format        | Description                                                                                                              |
@@ -80,7 +79,6 @@ The following is an excerpt from the default `Main.sublime-menu` file.
     }
 ]
 ```
-
 
 ## *Menu Item* Objects
 

--- a/docs/reference/menus.md
+++ b/docs/reference/menus.md
@@ -22,8 +22,7 @@ title: Menus
 
 ### Example
 
-The following is an excerpt
-from the default `Main.sublime-menu` file.
+The following is an excerpt from the default `Main.sublime-menu` file.
 
 ```json
 [
@@ -33,22 +32,50 @@ from the default `Main.sublime-menu` file.
         "id": "edit",
         "children":
         [
-            { "command": "undo", "mnemonic": "U" },
-            { "command": "redo_or_repeat", "mnemonic": "R" },
             {
-                "caption": "Undo Selection",
-                "children":
-                [
-                    { "command": "soft_undo" },
-                    { "command": "soft_redo" }
-                ]
+                "command": "undo",
+                "mnemonic": "U"
             },
-            { "caption": "-", "id": "clipboard" },
-            { "command": "copy", "mnemonic": "C" },
-            { "command": "cut", "mnemonic": "t" },
-            { "command": "paste", "mnemonic": "P" },
-            { "command": "paste_and_indent", "mnemonic": "I" },
-            { "command": "paste_from_history", "caption": "Paste from History" }
+            {
+                "command": "redo_or_repeat",
+                "mnemonic": "R"
+            },
+            {
+            "caption": "Undo Selection",
+            "children":
+            [
+                {
+                    "command": "soft_undo"
+                },
+                {
+                    "command": "soft_redo"
+                }
+            ]
+            },
+            {
+                "caption": "-",
+                "id": "clipboard"
+            },
+            {
+                "command": "copy",
+                "mnemonic": "C"
+            },
+            {
+                "command": "cut",
+                "mnemonic": "t"
+            },
+            {
+                "command": "paste",
+                "mnemonic": "P"
+            },
+            {
+                "command": "paste_and_indent",
+                "mnemonic": "I"
+            },
+            {
+                "command": "paste_from_history",
+                "caption": "Paste from History"
+            }
         ]
     }
 ]
@@ -61,39 +88,34 @@ from the default `Main.sublime-menu` file.
 
 [Menu items]: /guide/customization/menus.md#menu-items
 
-Unless you are referencing an existing item via ID,
-each menu item must define either
-`children`, `command` or `caption`.
+Unless you are referencing an existing item via ID, each menu item must define
+either `children`, `command` or `caption`.
 
 `command`
-: Name of the command to be called
-  when the menu item is selected.
+: Name of the command to be called when the menu item is selected.
 
 `args`
 : Object of arguments to the command.
-  For **Side Bar** and **Side Bar Mount Point** menus,
-  this is extended by a `files` argument
-  that contains all selected items in the sidebar as a list.
+  For **Side Bar** and **Side Bar Mount Point** menus, this is extended by a
+  `files` argument that contains all selected items in the sidebar as a list.
 
 `caption`
 : Text to be displayed in the menu.
-  A single hyphen (`-`) turns the item
-  into a [Menu Separator][].
+  A single hyphen (`-`) turns the item into a [Menu Separator][].
 
 `children`
-: List of [*Menu Item* objects](#menu-item-objects) that are displayed
-  when the item is hovered.
+: List of [*Menu Item* objects](#menu-item-objects) that are displayed when the
+  item is hovered.
   Overrides existence of `command` property.
 
 `mnemonic`
 : A single character used for menu accelerators.
-  The character must be contained in the caption
-  and is case-sensitive.
+  The character must be contained in the caption and is case-sensitive.
 
 `id`
 : A unique string identifier for the menu item.
-  This can be used to extend menu sections or sub-menu
-  or to alter a menu item entirely.
+  This can be used to extend menu sections or sub-menu or to alter a menu item
+  entirely.
 
   Refer to the [main documentation][item-ids] on how this works.
 

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -271,4 +271,5 @@ Subelements of `shellVariables` are dictionaries with `name` and `value` keys.
 
 ## Related API Functions
 
-To extract metadata information from plugin code, you can use the `view.meta_info(key, point)` API call.
+To extract metadata information from plugin code, you can use the
+`view.meta_info(key, point)` API call.

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -2,41 +2,36 @@
 title: Metadata Files
 ---
 
-Metadata are parameters
-that can be assigned to certain text sections
-using scope selectors.
+Metadata are parameters that can be assigned to certain text sections using
+scope selectors.
 
 <!-- TODO ref scope selectors -->
 
-These paremeters can be used
-for many purposes; for example:
+These paremeters can be used for many purposes; for example:
 
-- specifying the current comment markers,
-  even within embedded source code,
-  so that you can toggle comments in any syntax,
+- specifying the current comment markers, even within embedded source code, so
+  that you can toggle comments in any syntax,
 - defining rules for auto-indentation,
 - marking symbols that Sublime Text will allow you to
   [browse to quickly][goto-anything].
 
 <!-- TODO Link to the separate comment and symbol sections from here -->
 
-Furthermore, snippets can access metadata
-declared in the `shellVariables` setting,
-which allows you to create a snippet
-that has different contents
+Furthermore, snippets can access metadata declared in the `shellVariables`
+setting, which allows you to create a snippet that has different contents
 depending on where it's used.
 
 [goto-anything]: /guide/file-management/navigation.md#goto-anything
 
-
 ## File Format
 
-Metadata files have the `.tmPreferences` extension
-and use the Property List format.
+Metadata files have the `.tmPreferences` extension and use the Property List
+format.
 The file name is ignored by Sublime Text.
 
-Metadata files are inherited from TextMate.
+<!-- TODO: add link to plist docs -->
 
+Metadata files are inherited from TextMate.
 
 ## Example
 
@@ -44,7 +39,6 @@ Here's an example of a metadata file:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
    <key>name</key>
@@ -93,18 +87,17 @@ Here's an example of a metadata file:
 </plist>
 ```
 
-The example file combines
-several types of metadata.
-
+The example file combines several types of metadata.
 
 ## Structure of a Metadata File
 
-All metadata files share the same topmost structure,
-which is inherited from the Property List format.
+All metadata files share the same topmost structure, which is inherited from the
+Property List format.
+
+<!-- TODO: add plist docs -->
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
    ...
@@ -112,8 +105,7 @@ which is inherited from the Property List format.
 </plist>
 ```
 
-Sublime Text uses the following topmost keys
-in metadata files;
+Sublime Text uses the following topmost keys in metadata files;
 all others are ignored by default.
 
 `name`
@@ -128,8 +120,7 @@ all others are ignored by default.
 
 `scope`
 : **Required.**
-  Scope selector to determine
-  in which context the metadata should be available.
+  Scope selector to determine in which context the metadata should be available.
 
   ```xml
   <key>scope</key>
@@ -160,13 +151,11 @@ all others are ignored by default.
 
 ## Subelements of `settings`
 
-The `settings` element can contain
-subelements for different purposes,
-which will be grouped in the following sections.
+The `settings` element can contain subelements for different purposes, which
+will be grouped in the following sections.
 
 Some subelements have certain functionality associated with them by default,
 while others can only be accessed via the [API][].
-
 
 ### Indentation Options
 
@@ -174,8 +163,8 @@ Indentation options control aspects of the auto-indentation mechanism.
 
 `increaseIndentPattern`
 : *Regex.*
-  If it matches on the current line,
-  the next line will be indented one level further.
+  If it matches on the current line, the next line will be indented one level
+  further.
 
   ```xml
   <key>increaseIndentPattern</key>
@@ -184,8 +173,7 @@ Indentation options control aspects of the auto-indentation mechanism.
 
 `decreaseIndentPattern`
 : *Regex.*
-  If it matches on the current line,
-  the next line will be unindented one level.
+  If it matches on the current line, the next line will be unindented one level.
 
   ```xml
   <key>decreaseIndentPattern</key>
@@ -194,8 +182,8 @@ Indentation options control aspects of the auto-indentation mechanism.
 
 `bracketIndentNextLinePattern`
 : *Regex.*
-  If it matches on the current line,
-  only the next line will be indented one level further.
+  If it matches on the current line, only the next line will be indented one
+  level further.
 
   ```xml
   <key>bracketIndentNextLinePattern</key>
@@ -204,8 +192,7 @@ Indentation options control aspects of the auto-indentation mechanism.
 
 `disableIndentNextLinePattern`
 : *Regex.*
-  If it matches on the current line,
-  the next line will not be indented further.
+  If it matches on the current line, the next line will not be indented further.
 
   ```xml
   <key>disableIndentNextLinePattern</key>
@@ -214,15 +201,13 @@ Indentation options control aspects of the auto-indentation mechanism.
 
 `unIndentedLinePattern`
 : *Regex.*
-  The auto-indenter will ignore
-  lines matching this regex
-  when computing the next line's indentation level.
+  The auto-indenter will ignore lines matching this regex when computing the
+  next line's indentation level.
 
   ```xml
   <key>unIndentedLinePattern</key>
   <string>insert regex here</string>
   ```
-
 
 ### Completions Options
 
@@ -230,35 +215,29 @@ Completion options control aspects of the completions mechanism.
 
 `cancelCompletion`
 : *Regex.*
-  If it matches on the current line,
-  supresses the autocomplete popup.
+  If it matches on the current line, supresses the autocomplete popup.
 
   ```xml
   <key>cancelCompletion</key>
   <string>insert regex here</string>
   ```
 
-
 ### Symbol Definitions
 
-Documentation for symbol definitions
-was moved to a separate page:
+Documentation for symbol definitions was moved to a separate page:
 [Symbol Definition settings][].
 
 [Symbol Definition settings]: ./symbols.md#settings-subelements
 
-
 ### Shell Variables
 
-Shell variables are used for different purposes
-and can be accessed from snippets.
+Shell variables are used for different purposes and can be accessed from
+snippets.
 
-<!-- TODO reference to section in snippets once added -->
+<!-- TODO: reference to section in snippets once added -->
 
-Note that shell variables are defined
-as dictionaries in an array,
-and thus have a different format
-from `settings` subelements.
+Note that shell variables are defined as dictionaries in an array, and thus have
+a different format from `settings` subelements.
 
 `shellVariables`
 : Container for "shell variables".
@@ -272,8 +251,7 @@ from `settings` subelements.
 
 #### `shellVariables` Subelements
 
-Subelements of `shellVariables` are
-dictionaries with `name` and `value` keys.
+Subelements of `shellVariables` are dictionaries with `name` and `value` keys.
 
 ```xml
 <dict>
@@ -293,6 +271,4 @@ dictionaries with `name` and `value` keys.
 
 ## Related API Functions
 
-To extract metadata information from plugin code,
-you can use the `view.meta_info(key, point)`
-API call.
+To extract metadata information from plugin code, you can use the `view.meta_info(key, point)` API call.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,24 @@
 {
+  "name": "docs.sublimetext.io",
+  "private": true,
+  "description": "Sublime Text Community Documentation",
+  "homepage": "https://docs.sublimetext.io",
+  "bugs": {
+    "url": "https://github.com/sublimetext-io/docs.sublimetext.io/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sublimetext-io/docs.sublimetext.io.git"
+  },
   "scripts": {
     "build": "vuepress build docs",
     "check-md": "vuepress check-md docs",
     "dev": "vuepress dev docs"
+  },
+  "engines": {
+    "node": ">= 14.1.0",
+    "npm": ">= 6.14.5",
+    "yarn": ">= 1.22.4"
   },
   "dependencies": {
     "axios": "^0.19.2",
@@ -10,7 +26,7 @@
     "markdown-it-deflist": "^2.0.3",
     "markdown-it-footnote": "^3.0.2",
     "vue-click-outside": "^1.1.0",
-    "vuepress": "^1.4.0",
+    "vuepress": "^1.4.1",
     "vuepress-plugin-container": "^2.1.2",
     "vuepress-plugin-glossary": "^1.0.2"
   },


### PR DESCRIPTION
## ⚠️ DO NOT MERGE: WIP

- break lines at 80 or end of sentence
    - as diffs for whole sentences are easier to read
- move linebreaks where they were wrong
- add some missing backticks for inline code
- target base URL for Sublime Text docs as it redirects to ST3 docs for now, but will update when Will removes those and publishes the new ones as a replacement
- add some TODO and FIXME
    - please see comments in commits listed here (below)

## Todo

- [ ] make use of badges for supported ST version, compare [badge docs](https://vuepress.vuejs.org/guide/using-vue.html#badge)
    - or use component
- [ ] add `Key.vue` as a backup?
    - `forward_slash`
    - `plus`
    - `minus`
    - `equals`

## Notes

I use the SublimeLinter addon for annotations to keep track of TODOs.