### PR TITLE
Use `<kdb>` syntax to fix render.

### DIFF
--- a/docs/guide/extensibility/completions.md
+++ b/docs/guide/extensibility/completions.md
@@ -27,7 +27,7 @@ the two methods produce different results.
 Completions can be inserted in two ways:
 
 - through the completions list (<Key k="ctrl+space" />), or
-- by pressing <Key k="tab" />.
+- by pressing <kbd>Tab</kbd>.
 
 
 ### The Completions List


### PR DESCRIPTION
Is there a reason `<Key k=` is used instead of `<kbd>`. The latter would also render correctly in the source file in GitHub. The former does not render correctly for me in the site (Firefox on Mac OS), it appears as below:

<img width="383" alt="Screen Shot 2020-06-12 at 12 23 05 PM" src="https://user-images.githubusercontent.com/772937/84539089-aa9aa980-aca7-11ea-99d3-f5cf6e31634a.png">