### PR TITLE
Add "custom setups" section

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -119,6 +119,16 @@ const config = {
                         'extensibility/syntaxdefs.md',
                     ],
                 },
+                {
+                    title: 'Example Setups',
+                    path: '/guide/setup-examples/',
+                    collapsable: false,
+                    children: [
+                        'setup-examples/',
+                        'setup-examples/julia.md',
+                        'setup-examples/remote_dev.md',
+                    ],
+                },
             ],
             '/reference/': [
                 {

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -37,6 +37,9 @@ of this guide via the navigation bar on top.
 You can always go back to this page
 by clicking on "Guide" in that same bar.
 
+If you want to know how to use Sublime for a particular worflow
+or progamming language you can check [Example setups][].
+
 **Happy learning!**
 
 ::: tip One last note before you dive in
@@ -50,6 +53,7 @@ Other than that, this site site can be used without JavaScript.
 
 [Sublime Text]: https://www.sublimetext.com/
 [Basic Concepts]: ./getting-started/basic-concepts.md
+[Example setups]: ./setup-examples/README.md
 
 
 ## History

--- a/docs/guide/setup-examples/README.md
+++ b/docs/guide/setup-examples/README.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Example setups
 ---
 
 This contains "How to use Sublime with X" guides.

--- a/docs/guide/setup-examples/README.md
+++ b/docs/guide/setup-examples/README.md
@@ -1,0 +1,16 @@
+---
+title: Introduction
+---
+
+This contains "How to use Sublime with X" guides.
+Those guides are opiniated and may not match your workflow,
+but they can help you get started
+when working on a new language/technology.
+
+## Programming Languages
+
+* [How to use Sublime with Julia](./julia.md)
+
+## Workflow
+
+* [How to use Sublime for remote development](./remote_dev.md)

--- a/docs/guide/setup-examples/README.md
+++ b/docs/guide/setup-examples/README.md
@@ -9,8 +9,8 @@ when working on a new language/technology.
 
 ## Programming Languages
 
-* [How to use Sublime with Julia](./julia.md)
+- [How to use Sublime with Julia](./julia.md)
 
 ## Workflow
 
-* [How to use Sublime for remote development](./remote_dev.md)
+- [How to use Sublime for remote development](./remote_dev.md)

--- a/docs/guide/setup-examples/julia.md
+++ b/docs/guide/setup-examples/julia.md
@@ -1,0 +1,330 @@
+---
+title: How to use Sublime for Julia development
+---
+
+Adapted from https://github.com/PetrKryslUCSD/HowToUseJuliaWithSublimeText3
+This guide was written by a Windows user, that uses the Windows Subsystem for Linux to run Julia.
+
+When working with Julia, I like having my source code on the left and a terminal running Julia REPL on the right.
+This setup will allow you to have the terminal inside Sublime
+and to have commands that send code under your cursor to the REPL for evaluation.
+
+## Installation
+
+### Install Julia syntax highlighting
+
+Install the [Julia](https://github.com/JuliaEditorSupport/Julia-sublime) package.
+Bring up the **Command Palette**, and type in a few letters of **Package Control: Install Package**.
+When it comes up, select it.
+Loading the registry will take a couple of seconds, and then we get window where we can type in `Julia`.
+A button named **Julia** (with the subtitle "Julia syntax highlighting for Sublime Text 2/3") will come up highlighted.
+Click on it, and the package will be installed.
+At this point one should be able to open a Julia source file and get it highlighted based upon the syntax of Julia.
+
+### Install the Terminus and SendCode packages
+
+As before use **Package Control** to install the terminal emulation package [Terminus](https://github.com/randy3k/Terminus),
+and the package to enable communication between a source window and the terminal, [SendCode](https://github.com/randy3k/SendCode).
+
+## Customization
+
+The key bindings file and the other customization files for the user live in the folder for user settings. In my case that is `C:\Users\PetrKrysl\AppData\Roaming\Sublime Text 3\Packages\User`. For brevity I will call this folder `USER`.
+You can find yours through the Command Palette: `Browse Packages`.
+
+
+### Key bindings
+
+Here are the key-bindings that I'm using 
+The key bindings may seem Baroque, but I use voice recognition which means I say a command, which sends these keys. (The point is to avoid typing these contortions on the keyboard.)
+Don't hesitate to adapt those key-bindings to something simpler.
+
+From the menu, select **Preferences/Key bindings**. This will open a new window with
+the file`Default (Windows).sublime-keymap`, shown in the window on the right.
+I put in there my personal preferences for key bindings.
+
+
+```json
+[
+    // This key binding gives me access to code evaluation. A current line,
+    // or a selection is passed to the terminal for evaluation
+    // (the command belongs to the SendCode package).
+    {
+        "keys": ["ctrl+keypad_enter"], "command": "send_code",
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "source" }
+        ]
+    },
+    // Send code to change the working folder to that holding the current Julia file
+    {
+        "keys": ["ctrl+shift+x", "ctrl+f"], "command": "send_code",
+        "args": {"cmd": "cd(\"$file_path\")"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "source.julia" }
+        ]
+    },
+    // Send code to display help information.
+    {
+        "keys": ["ctrl+shift+x", "ctrl+h"], "command": "send_code",
+        "args": {"cmd": "REPL.@repl $selection"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "source.julia" }
+        ]
+    },
+    // Send code to display help information. 
+    {
+        "keys": ["ctrl+shift+x", "ctrl+alt+h"], "command": "send_code",
+        "args": {"cmd": "?$selection"},
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "source.julia" }
+        ]
+    },
+
+    // By default in Terminus the ctrl key sends escape code to the terminal.
+    // This can be disturbing if you're use to ctrl+c/ctrl+v for copy/paste
+    // To make the copy and paste keys work in the Terminus window
+    // (otherwise they are ctrl+shift+c, ctrl+shift+v)
+    { "keys": ["ctrl+c"], "command": "terminus_copy",
+        "context": [
+            { "key": "terminus_view" },
+            { "key": "terminus_view.natural_keyboard" },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+        ]
+    },
+    { "keys": ["ctrl+v"], "command": "terminus_paste",
+        "context": [
+            { "key": "terminus_view" },
+            { "key": "terminus_view.natural_keyboard" }
+        ]
+    },
+    // This is to make the "go to anything" key available in the Terminus view
+    {
+        "keys": ["ctrl+p"],
+        "command": "show_overlay",
+        "args": {"overlay": "goto", "show_files": true},
+        "context": [
+            { "key": "terminus_view" },
+        ]
+    },
+]
+```
+
+### Customization of the Terminus package
+
+In the file
+`USER\Terminus.sublime-settings` I customize the Linux shell of the Windows Subsystem for Linux, which in my case is Ubuntu 18.04.
+I also set it to be the default shell to be started by Terminus:
+
+```json
+{
+    // a list of available shells to execute
+    // the shell marked as "default" will be the default shell
+    "shell_configs": [
+        {
+            "name": "Command Prompt",
+            "cmd": "bash.exe",
+            "env": {},
+            "enable": true,
+            "default": true,
+            "platforms": ["windows"]
+        },
+        {
+            "name": "Bash",
+            "cmd": ["bash", "-i", "-l"],
+            "env": {},
+            "enable": true,
+            "default": false,
+            "platforms": ["linux", "osx"]
+        },
+        {
+            "name": "Zsh",
+            "cmd": ["zsh", "-i", "-l"],
+            "env": {},
+            "enable": true,
+            "default": false,
+            "platforms": ["linux", "osx"]
+        },
+        {
+            "name": "Ubuntu 18.04 Login Shell",
+            "cmd": "C:\\Program Files\\WindowsApps\\CanonicalGroupLimited.UbuntuonWindows_1804.2019.521.0_x64__79rhkp1fndgsc\\ubuntu.exe",
+            "env": {},
+            "enable": true,
+            "default": false,
+            "platforms": ["windows"]
+        }
+    ],
+}
+```
+
+### Customization of the SendCode package
+
+I make sure Julia code is sent to a **Terminus** terminal. Select **Preferences/Package Settings/SendCode/Settings**. Paste the below code into this file.
+
+```json
+{
+    "prog": "terminus",
+
+    "julia" : {
+        "prog": "terminus",
+        "bracketed_paste_mode": false
+    }
+
+}
+```
+There also needs to be a file `Packages\SendCode\support\Julia - Source File.sublime-build` with the command to "build" a Julia file by running it in the REPL.
+```
+{
+    "target": "send_code_build",
+    "cmd": "include(\"${file_name}\");",
+    "selector": "source.julia"
+}
+```
+
+### Command to start Julia REPL
+
+In order to be able to open a Julia REPL from a Julia source file currently opened in the editor,
+I define the following command binding in the file `USER\Default.sublime-commands`:
+```json
+[
+    {
+        "caption": "Terminus: Open Julia Stable",
+        "command": "terminus_open",
+        "args"   : {//"shell_cmd": "%LOCALAPPDATA%/Programs/Julia/Julia-1.4.1/bin/julia.exe",
+            "shell_cmd": "%LOCALAPPDATA%\\Programs\\Julia\\Julia-1.4.1\\bin\\julia.exe",
+            "cwd": "${file_path:${folder}}",
+            "title": "Julia REPL",
+            "pre_window_hooks": [
+                ["focus_group", {"group": 1}]
+            ],
+            "env": {"JULIA_NUM_THREADS":"4"},
+        }
+    },
+    {
+        "caption": "Terminus: Open Julia Nightly",
+        "command": "terminus_open",
+        "args"   : {
+            "shell_cmd": "%LOCALAPPDATA%\\Programs\\\"Julia 1.5.0-DEV\"\\bin\\julia.exe",
+            "cwd": "${file_path:${folder}}",
+            "title": "Julia Nightly REPL",
+            "pre_window_hooks": [
+                ["focus_group", {"group": 1}]
+            ],
+            "env": {"JULIA_NUM_THREADS":"1"},
+        }
+    }
+]
+```
+
+Note that the above assumes that the Julia executable, `julia`, is in the default location specified by the installer. Note that  we can have multiple  commands for different versions of Julia. So in the Command Palette either choose the command **Terminus: Open Julia 1.3** or the command **Terminus: Open Julia Nightly**. Note the magic incantation to allow for a space in the Julia-development path: the quoting `"%LOCALAPPDATA%\\Programs\\\"Julia 1.5.0-DEV\"\\bin\\julia.exe"` is needed to make it work.
+
+Also, it is possible to set the environment variable directing the use of threading, `JULIA_NUM_THREADS`. Extending this to other environment variables is likely to be successful as well.
+
+Finally, the editor gives focus to the top-most file in the group 1. This is useful when two columns or two rows are used for the layout. Opening Julia with the cursor in a source file then places the REPL in the other view.
+
+### Snippets
+
+The **Julia** mode package comes with predefined snippets (check out the [github site](https://github.com/JuliaEditorSupport/Julia-sublime)). I have defined some of my own, such as this one
+to speed up the specification of a doc string (file `docstring.sublime-snippet`):
+```
+<snippet>
+    <content><![CDATA[
+"""
+    ${1:bar(x[, y])}
+
+${0:Compute}
+"""
+]]></content>
+    <tabTrigger>docs</tabTrigger>
+    <scope>source.julia</scope>
+</snippet>
+```
+The snippets go into one file per snippet, which I put in `USER\snippets`.
+The current selection of snippets is part of this repository in the `snippets` folder.
+
+## Usage
+
+### Open terminal
+
+Bring up the **Command Palette**, start typing in `Terminus`. Select **Terminus: List Shells**, and from the list that appears choose the shell you wish to start. Note that then you can select whether to start the shell in a panel at the bottom or in a separate view.
+
+Julia may be started in the resulting terminal in the usual way. The terminals that I have checked out (`cmd` and the WSL Ubuntu shell) work as expected.
+
+### Open a source file and then run Julia from the source file
+
+Open a Julia source file, and in the **Command Palette**, start typing in `Terminus`. Select **Terminus: Open Julia**. This will open the default terminal on the user's platform (`cmd` on Windows, but see also the note about the Git bash below), and run Julia in the directory that contains the open file.
+
+### Evaluating code
+
+Select some Julia code and press `ctrl+enter`. The code will be pasted into the **Terminus** window and evaluated in Julia (assuming Julia was started in that **Terminus** window).
+This also works for evaluating a line of code: place the cursor on a line and type `ctrl+enter`.
+
+#### Running Julia files
+In a currently opened Julia source file,
+press `ctrl+b` (which is a key binding for the menu action **Tools/Build**).
+The current file will be evaluated in a Julia-running **Terminus** window with an `include()`.
+
+### Asking for help in the REPL
+
+There is a key binding to send code to the REPL to invoke the help mode on the selection using the `send_code` command (see the key bindings above).
+
+## Zeal
+
+Zeal is an open-source browser of off-line documentation.
+There is a Sublime package that allows you to jump to Zeal documentation for the symbol under cursor.
+Zeal can also be used with other languages than Julia.
+Zeal can be downloaded from
+[https://zealdocs.org/download.html](https://zealdocs.org/download.html).
+The documentation for Julia needs to be downloaded within the Zeal documentation browser:
+in the menu "Tools" choose "Docsets".
+
+From **Package Control** install [Zeal for Sublime Text 2/3](https://packagecontrol.io/packages/Zeal).
+
+The Zeal executable needs to be revealed to the editor. Also, Zeal
+needs to be made aware of the language of the documentation request:
+```json
+{
+  /**
+   Zeal executable path. The instructions below require zeal
+   to be located very precisely by its full path!?
+   */
+  "zeal_command": "C:\\Program Files\\Zeal\\zeal.exe",
+  "mapping_sort" : true,
+
+  // Language mapping.
+  "language_mapping": {
+    "Python": {"lang": "python", "zeal_lang": "python"},
+    "Julia": {"lang": "julia", "zeal_lang": "julia"}
+  }
+}
+```
+
+Zeal can be brought up by pressing `F1` or through the Command Palette.
+
+
+## Starts Julia from Git Bash 
+
+I really can't stand the default "shell" (CMD) in which Julia starts on
+Windows. The interaction with the shell is quite unsatisfactory then: most of the Windows commands and all of the UNIX
+commands don't work as one would expect. What I prefer instead is [Git Bash]
+(https://git-scm.com/downloads). One can get that to run Julia by starting
+Sublime Text  from a bat file. I create such a file with the line
+``` cmd /C
+start "" "%PROGRAMFILES%\\Git\\bin\\sh.exe" --login -i -c "exec
+\"C:\Users\PetrKrysl\Documents\Productivity\PortableSublimeText\sublime_text.exe\""
+```
+where my portable Sublime Text executable is invoked from within the Git
+shell.
+
+In order to get an executable file with the Sublime Text icon, I create a
+shortcut (for instance to be placed on the desktop), and I give it the icon
+which is part of this repository.
+
+Alternatively, start the Git Bash terminal, and run the `subl` executable of
+your portable Sublime Text. When a terminal is opened inside the running
+editor, it runs the Git Bash. In particular, when Julia is started in the
+editor, its shell mode drops you to the Bash. Perfect!
+
+
+## Credits
+
+Thanks to Petr Krysl, Paul Soderlind, @mbauman.
+[Original source](https://github.com/PetrKryslUCSD/HowToUseJuliaWithSublimeText3).

--- a/docs/guide/setup-examples/julia.md
+++ b/docs/guide/setup-examples/julia.md
@@ -6,30 +6,27 @@ Adapted from https://github.com/PetrKryslUCSD/HowToUseJuliaWithSublimeText3
 This guide was written by a Windows user,
 that uses the Windows Subsystem for Linux to run Julia.
 
-When working with Julia,
-I like having my source code on the left
+This guide will help you have 
+source code on the left
 and a terminal running Julia REPL on the right.
-This setup will allow you to have the terminal inside Sublime
-and to have commands that send code under your cursor to the REPL.
+The terminal will be running inside Sublime
+and you will have commands
+that send code under your cursor 
+or the whole file
+to the REPL.
 
 ## Installation
 
 ### Install Julia syntax highlighting
 
-Install the [Julia][] package.
-Bring up the **Command Palette**,
-and type in a few letters of **Package Control: Install Package**.
-When it comes up, select it.
-Loading the registry will take a couple of seconds,
-and then we get window where we can type in `Julia`.
-A button named **Julia**
-(with the subtitle "Julia syntax highlighting for Sublime Text 2/3")
-will come up highlighted.
-Click on it, and the package will be installed.
-At this point one should be able to open a Julia source file
+Install the [Julia][] package,
+using Package Control.
+(See [Installing Packages][] for more details.)
+At this point you should be able to open a Julia source file
 and get it highlighted based upon the syntax of Julia.
 
-[Julia]: https://github.com/JuliaEditorSupport/Julia-sublime
+[Julia]: https://packagecontrol.io/packages/Julia
+[Installing Packages]: https://docs.sublimetext.io/guide/extensibility/packages.html#installing-packages
 
 ### Install the Terminus and SendCode packages
 
@@ -53,11 +50,9 @@ You can find yours through the Command Palette: `Browse Packages`.
 
 ### Key bindings
 
-Here are the key-bindings that I'm using.
-The key bindings may seem Baroque,
-but I use voice recognition which means I say a command,
-which sends these keys.
-(The point is to avoid typing these contortions on the keyboard.)
+The following key-bindings will help you getting started.
+Those key-bindings are made for Windows / Linux,
+and have been chosen to avoid conflicts.
 Don't hesitate to adapt those key-bindings to something simpler.
 
 From palette: **Preferences: Key bindings**.
@@ -106,6 +101,7 @@ Put there your key bindings.
     // This can be disturbing if you're use to ctrl+c/ctrl+v for copy/paste
     // To make the copy and paste keys work in the Terminus window
     // (otherwise they are ctrl+shift+c, ctrl+shift+v)
+    // This is not needed on MacOS.
     { "keys": ["ctrl+c"], "command": "terminus_copy",
         "context": [
             { "key": "terminus_view" },
@@ -119,7 +115,7 @@ Put there your key bindings.
             { "key": "terminus_view.natural_keyboard" }
         ]
     },
-    // This is to make the "go to anything" key available in the Terminus view
+    // Same thing with the "go to anything".
     {
         "keys": ["ctrl+p"],
         "command": "show_overlay",
@@ -133,10 +129,12 @@ Put there your key bindings.
 
 ### Customization of the Terminus package
 
-In the file `USER\Terminus.sublime-settings`
-I customize the Linux shell of the Windows Subsystem for Linux,
-which in my case is Ubuntu 18.04.
-I also set it to be the default shell to be started by Terminus:
+In the file `USER\Terminus.sublime-settings`,
+chose your favorite shell.
+
+customize the Linux shell of the Windows Subsystem for Linux,
+(Ubuntu 18.04 in this guide).
+Set it to be the default shell to be started by Terminus:
 
 ```json
 {
@@ -149,6 +147,14 @@ I also set it to be the default shell to be started by Terminus:
             "env": {},
             "enable": true,
             "default": true,
+            "platforms": ["windows"]
+        },
+        {
+            "name": "Ubuntu 18.04 Login Shell",
+            "cmd": "C:\\Program Files\\WindowsApps\\CanonicalGroupLimited.UbuntuonWindows_1804.2019.521.0_x64__79rhkp1fndgsc\\ubuntu.exe",
+            "env": {},
+            "enable": true,
+            "default": false,
             "platforms": ["windows"]
         },
         {
@@ -166,14 +172,6 @@ I also set it to be the default shell to be started by Terminus:
             "enable": true,
             "default": false,
             "platforms": ["linux", "osx"]
-        },
-        {
-            "name": "Ubuntu 18.04 Login Shell",
-            "cmd": "C:\\Program Files\\WindowsApps\\CanonicalGroupLimited.UbuntuonWindows_1804.2019.521.0_x64__79rhkp1fndgsc\\ubuntu.exe",
-            "env": {},
-            "enable": true,
-            "default": false,
-            "platforms": ["windows"]
         }
     ],
 }
@@ -372,7 +370,7 @@ The interaction with the shell is quite unsatisfactory then:
 most of the Windows commands and all of the UNIX commands
 don't work as one would expect.
 What I prefer instead is [Git Bash](https://git-scm.com/downloads).
-One can get that to run Julia by starting Sublime Text  from a bat file.
+One can get that to run Julia by starting Sublime Text from a bat file.
 I create such a file with the line:
 
 ```

--- a/docs/guide/setup-examples/julia.md
+++ b/docs/guide/setup-examples/julia.md
@@ -3,44 +3,67 @@ title: How to use Sublime for Julia development
 ---
 
 Adapted from https://github.com/PetrKryslUCSD/HowToUseJuliaWithSublimeText3
-This guide was written by a Windows user, that uses the Windows Subsystem for Linux to run Julia.
+This guide was written by a Windows user,
+that uses the Windows Subsystem for Linux to run Julia.
 
-When working with Julia, I like having my source code on the left and a terminal running Julia REPL on the right.
+When working with Julia,
+I like having my source code on the left
+and a terminal running Julia REPL on the right.
 This setup will allow you to have the terminal inside Sublime
-and to have commands that send code under your cursor to the REPL for evaluation.
+and to have commands that send code under your cursor to the REPL.
 
 ## Installation
 
 ### Install Julia syntax highlighting
 
-Install the [Julia](https://github.com/JuliaEditorSupport/Julia-sublime) package.
-Bring up the **Command Palette**, and type in a few letters of **Package Control: Install Package**.
+Install the [Julia][] package.
+Bring up the **Command Palette**,
+and type in a few letters of **Package Control: Install Package**.
 When it comes up, select it.
-Loading the registry will take a couple of seconds, and then we get window where we can type in `Julia`.
-A button named **Julia** (with the subtitle "Julia syntax highlighting for Sublime Text 2/3") will come up highlighted.
+Loading the registry will take a couple of seconds,
+and then we get window where we can type in `Julia`.
+A button named **Julia**
+(with the subtitle "Julia syntax highlighting for Sublime Text 2/3")
+will come up highlighted.
 Click on it, and the package will be installed.
-At this point one should be able to open a Julia source file and get it highlighted based upon the syntax of Julia.
+At this point one should be able to open a Julia source file
+and get it highlighted based upon the syntax of Julia.
+
+[Julia]: https://github.com/JuliaEditorSupport/Julia-sublime
 
 ### Install the Terminus and SendCode packages
 
-As before use **Package Control** to install the terminal emulation package [Terminus](https://github.com/randy3k/Terminus),
-and the package to enable communication between a source window and the terminal, [SendCode](https://github.com/randy3k/SendCode).
+As before use Package Control to install the terminal emulation package
+[Terminus][],
+and the package to enable communication between a source window
+and the terminal, [SendCode][].
+
+[Terminus]: https://github.com/randy3k/Terminus
+[SendCode]: https://github.com/randy3k/SendCode
 
 ## Customization
 
-The key bindings file and the other customization files for the user live in the folder for user settings. In my case that is `C:\Users\PetrKrysl\AppData\Roaming\Sublime Text 3\Packages\User`. For brevity I will call this folder `USER`.
+The key bindings file and the other customization files for the user
+live in the folder for user settings.
+In my case that is
+`C:\Users\PetrKrysl\AppData\Roaming\Sublime Text 3\Packages\User`.
+For brevity I will call this folder `USER`.
 You can find yours through the Command Palette: `Browse Packages`.
 
 
 ### Key bindings
 
-Here are the key-bindings that I'm using 
-The key bindings may seem Baroque, but I use voice recognition which means I say a command, which sends these keys. (The point is to avoid typing these contortions on the keyboard.)
+Here are the key-bindings that I'm using.
+The key bindings may seem Baroque,
+but I use voice recognition which means I say a command,
+which sends these keys.
+(The point is to avoid typing these contortions on the keyboard.)
 Don't hesitate to adapt those key-bindings to something simpler.
 
-From the menu, select **Preferences/Key bindings**. This will open a new window with
-the file`Default (Windows).sublime-keymap`, shown in the window on the right.
-I put in there my personal preferences for key bindings.
+From palette: **Preferences: Key bindings**.
+This will open a new window with the file `Default (Windows).sublime-keymap`,
+shown in the window on the right.
+Put there your key bindings.
 
 
 ```json
@@ -110,8 +133,9 @@ I put in there my personal preferences for key bindings.
 
 ### Customization of the Terminus package
 
-In the file
-`USER\Terminus.sublime-settings` I customize the Linux shell of the Windows Subsystem for Linux, which in my case is Ubuntu 18.04.
+In the file `USER\Terminus.sublime-settings`
+I customize the Linux shell of the Windows Subsystem for Linux,
+which in my case is Ubuntu 18.04.
 I also set it to be the default shell to be started by Terminus:
 
 ```json
@@ -157,7 +181,9 @@ I also set it to be the default shell to be started by Terminus:
 
 ### Customization of the SendCode package
 
-I make sure Julia code is sent to a **Terminus** terminal. Select **Preferences/Package Settings/SendCode/Settings**. Paste the below code into this file.
+I make sure Julia code is sent to a **Terminus** terminal.
+Select **Preferences → Package Settings → SendCode → Settings**.
+Paste the below config into this file.
 
 ```json
 {
@@ -170,7 +196,10 @@ I make sure Julia code is sent to a **Terminus** terminal. Select **Preferences/
 
 }
 ```
-There also needs to be a file `Packages\SendCode\support\Julia - Source File.sublime-build` with the command to "build" a Julia file by running it in the REPL.
+
+There also needs to be a file
+`Packages\SendCode\support\Julia - Source File.sublime-build`
+with the command to "build" a Julia file by running it in the REPL.
 ```
 {
     "target": "send_code_build",
@@ -181,8 +210,9 @@ There also needs to be a file `Packages\SendCode\support\Julia - Source File.sub
 
 ### Command to start Julia REPL
 
-In order to be able to open a Julia REPL from a Julia source file currently opened in the editor,
-I define the following command binding in the file `USER\Default.sublime-commands`:
+In order to be able to open a Julia REPL
+from a Julia source file opened in the editor,
+I define the following command binding in `USER\Default.sublime-commands`:
 ```json
 [
     {
@@ -214,15 +244,25 @@ I define the following command binding in the file `USER\Default.sublime-command
 ]
 ```
 
-Note that the above assumes that the Julia executable, `julia`, is in the default location specified by the installer. Note that  we can have multiple  commands for different versions of Julia. So in the Command Palette either choose the command **Terminus: Open Julia 1.3** or the command **Terminus: Open Julia Nightly**. Note the magic incantation to allow for a space in the Julia-development path: the quoting `"%LOCALAPPDATA%\\Programs\\\"Julia 1.5.0-DEV\"\\bin\\julia.exe"` is needed to make it work.
+Don't forget to update the `julia` path to where it was actually installed.
+We will now have multiple commands for different versions of Julia.
+So in the Command Palette either choose **Terminus: Open Julia Stable**
+or **Terminus: Open Julia Nightly**.
+Note the magic incantation to allow for a space in the Julia-development path:
+the quoting `"%LOCALAPPDATA%\\Programs\\\"Julia 1.5.0-DEV\"\\bin\\julia.exe"`
+is needed to make it work.
 
-Also, it is possible to set the environment variable directing the use of threading, `JULIA_NUM_THREADS`. Extending this to other environment variables is likely to be successful as well.
+It is possible to set environment variables like `JULIA_NUM_THREADS` here.
 
-Finally, the editor gives focus to the top-most file in the group 1. This is useful when two columns or two rows are used for the layout. Opening Julia with the cursor in a source file then places the REPL in the other view.
+Finally, the editor gives focus to the top-most file in the group 1.
+This is useful when two columns or two rows are used for the layout.
+Opening Julia with the cursor in a source file
+then places the REPL in the other view.
 
 ### Snippets
 
-The **Julia** mode package comes with predefined snippets (check out the [github site](https://github.com/JuliaEditorSupport/Julia-sublime)). I have defined some of my own, such as this one
+The [Julia][] package comes with predefined snippets.
+I have defined some of my own, such as this one
 to speed up the specification of a doc string (file `docstring.sublime-snippet`):
 ```
 <snippet>
@@ -238,52 +278,74 @@ ${0:Compute}
 </snippet>
 ```
 The snippets go into one file per snippet, which I put in `USER\snippets`.
-The current selection of snippets is part of this repository in the `snippets` folder.
+You can find more snippets on [Petr Github][].k
+
+[Petr Github]: https://github.com/PetrKryslUCSD/HowToUseJuliaWithSublimeText3/tree/master/snippets
 
 ## Usage
 
 ### Open terminal
 
-Bring up the **Command Palette**, start typing in `Terminus`. Select **Terminus: List Shells**, and from the list that appears choose the shell you wish to start. Note that then you can select whether to start the shell in a panel at the bottom or in a separate view.
+Bring up the **Command Palette**, start typing in `Terminus`.
+Select **Terminus: List Shells**,
+and from the list that appears choose the shell you wish to start.
+Note that then you can select whether to start the shell
+in a panel at the bottom or in a separate view.
 
-Julia may be started in the resulting terminal in the usual way. The terminals that I have checked out (`cmd` and the WSL Ubuntu shell) work as expected.
+Julia may be started in the resulting terminal in the usual way.
+The terminals that I have checked out (`cmd` and the WSL Ubuntu shell)
+work as expected.
 
 ### Open a source file and then run Julia from the source file
 
-Open a Julia source file, and in the **Command Palette**, start typing in `Terminus`. Select **Terminus: Open Julia**. This will open the default terminal on the user's platform (`cmd` on Windows, but see also the note about the Git bash below), and run Julia in the directory that contains the open file.
+Open a Julia source file,
+and in the **Command Palette**, start typing in `Terminus`.
+Select **Terminus: Open Julia**.
+This will open the default terminal on the user's platform
+(`cmd` on Windows, but see also the note about the Git bash below),
+and run Julia in the directory that contains the open file.
 
 ### Evaluating code
 
-Select some Julia code and press `ctrl+enter`. The code will be pasted into the **Terminus** window and evaluated in Julia (assuming Julia was started in that **Terminus** window).
-This also works for evaluating a line of code: place the cursor on a line and type `ctrl+enter`.
+Select some Julia code and press <Key k="ctrl+enter" />.
+The code will be pasted into the **Terminus** window
+and evaluated in Julia (assuming Julia was started in that **Terminus** window).
+This also works for evaluating a line of code:
+place the cursor on a line and type <Key k="ctrl+enter" />.
 
 #### Running Julia files
-In a currently opened Julia source file,
-press `ctrl+b` (which is a key binding for the menu action **Tools/Build**).
-The current file will be evaluated in a Julia-running **Terminus** window with an `include()`.
+
+In a opened Julia source file, press <Key k="ctrl+b" />
+(which is the key binding for **Tools → Build**).
+The current file will be evaluated in a Julia-running Terminus window
+with an `include()`.
 
 ### Asking for help in the REPL
 
-There is a key binding to send code to the REPL to invoke the help mode on the selection using the `send_code` command (see the key bindings above).
+From a Julia source file, press <Key k="ctrl+shift+x, ctrl+h"> to ask the Julia
+REPL to display help about the current selection.
 
 ## Zeal
 
 Zeal is an open-source browser of off-line documentation.
-There is a Sublime package that allows you to jump to Zeal documentation for the symbol under cursor.
+There is a Sublime package that allows you to jump to Zeal documentation
+for the symbol under cursor.
 Zeal can also be used with other languages than Julia.
-Zeal can be downloaded from
-[https://zealdocs.org/download.html](https://zealdocs.org/download.html).
+Zeal can be downloaded from [Zeal website][].
 The documentation for Julia needs to be downloaded within the Zeal documentation browser:
 in the menu "Tools" choose "Docsets".
 
-From **Package Control** install [Zeal for Sublime Text 2/3](https://packagecontrol.io/packages/Zeal).
+From Package Control install [Zeal for Sublime Text][].
 
-The Zeal executable needs to be revealed to the editor. Also, Zeal
+The Zeal executable needs to be revealed to the editor.
+Also, Zeal
 needs to be made aware of the language of the documentation request:
+
 ```json
 {
   /**
-   Zeal executable path. The instructions below require zeal
+   Zeal executable path.
+   The instructions below require zeal
    to be located very precisely by its full path!?
    */
   "zeal_command": "C:\\Program Files\\Zeal\\zeal.exe",
@@ -299,30 +361,39 @@ needs to be made aware of the language of the documentation request:
 
 Zeal can be brought up by pressing `F1` or through the Command Palette.
 
+[Zeal website]: https://zealdocs.org/download.html
+[Zeal for Sublime Text]: https://packagecontrol.io/packages/Zeal
 
 ## Starts Julia from Git Bash 
 
-I really can't stand the default "shell" (CMD) in which Julia starts on
-Windows. The interaction with the shell is quite unsatisfactory then: most of the Windows commands and all of the UNIX
-commands don't work as one would expect. What I prefer instead is [Git Bash]
-(https://git-scm.com/downloads). One can get that to run Julia by starting
-Sublime Text  from a bat file. I create such a file with the line
-``` cmd /C
+I really can't stand the default "shell" (CMD)
+in which Julia starts on Windows.
+The interaction with the shell is quite unsatisfactory then:
+most of the Windows commands and all of the UNIX commands
+don't work as one would expect.
+What I prefer instead is [Git Bash](https://git-scm.com/downloads).
+One can get that to run Julia by starting Sublime Text  from a bat file.
+I create such a file with the line:
+
+```
+cmd /C
 start "" "%PROGRAMFILES%\\Git\\bin\\sh.exe" --login -i -c "exec
 \"C:\Users\PetrKrysl\Documents\Productivity\PortableSublimeText\sublime_text.exe\""
 ```
-where my portable Sublime Text executable is invoked from within the Git
-shell.
 
-In order to get an executable file with the Sublime Text icon, I create a
-shortcut (for instance to be placed on the desktop), and I give it the icon
-which is part of this repository.
+where my portable Sublime Text executable is invoked from within the Git shell.
 
-Alternatively, start the Git Bash terminal, and run the `subl` executable of
-your portable Sublime Text. When a terminal is opened inside the running
-editor, it runs the Git Bash. In particular, when Julia is started in the
-editor, its shell mode drops you to the Bash. Perfect!
+In order to get an executable file with the Sublime Text icon,
+I create a shortcut (for instance to be placed on the desktop),
+and I give it the [ST icon][].
 
+Alternatively, start the Git Bash terminal,
+and run the `subl` executable of your portable Sublime Text.
+When a terminal is opened inside the running editor, it runs the Git Bash.
+In particular, when Julia is started in the editor,
+its shell mode drops you to the Bash. Perfect!
+
+[ST icon]: https://github.com/PetrKryslUCSD/HowToUseJuliaWithSublimeText3/blob/master/sublime-text.ico
 
 ## Credits
 

--- a/docs/guide/setup-examples/remote_dev.md
+++ b/docs/guide/setup-examples/remote_dev.md
@@ -1,15 +1,19 @@
 This steps should help working remotely with Sublime Text.
-They are meant to be incremental, just setting up SFTP will go a long way.
+They are meant to be incremental,
+just setting up SFTP will go a long way.
 
 # My workflow
 
-I have all my code on my laptop (a Mac), edit locally and automatically push the files to my server (a Linux machine).
+I have all my code on my laptop (a Mac),
+edit locally and automatically push the files to my server (a Linux machine).
 I never edit "tracked" files on the server directly.
-I sometimes modify untracked files or config files on the server using `rmate` (see below).
+I sometimes modify untracked files
+or config files on the server using `rmate` (see below).
 
 # SSH config
 
-Create a `~/.ssh/config` file, which allows reusing existing connection.
+Create a `~/.ssh/config` file,
+which allows reusing existing connection.
 This mean that you will have to authenticate only once.
 
 ```
@@ -26,18 +30,26 @@ Host server
 ```
 
 Check that it works by running "ssh server" in a terminal.
-Then in a second one. The second terminal shouldn't ask for credentials. 
-This will also allow Sublime to connect to your server without asking for credentials.
+Then in a second one.
+The second terminal shouldn't ask for credentials.
+
+This will also allow Sublime to connect to your server
+without asking for credentials.
 
 # SFTP setup
 
-SFTP is a Sublime Text package that will allow you to keep in sync files on your laptop and on a server.
+SFTP is a Sublime Text package that will allow you to keep in sync files
+on your laptop and on a server.
 
 Install https://packagecontrol.io/packages/SFTP
 Open your project in ST.
-From command palette: `SFTP: Setup Server`
-This will create a `sftp-config.json` at the root of your project. (You may want to add `sftp-config.json` to your [global gitignore](https://stackoverflow.com/a/7335487/3561471)).
-I recommend having the same project folder names on your server and on your laptop and keeping all your projects in the same folder. This will make advanced steps easier.
+From command palette: **SFTP: Setup Server**
+This will create a `sftp-config.json` at the root of your project.
+(You may want to add `sftp-config.json` to your [global gitignore][].
+I recommend having the same project folder names
+on your server and on your laptop
+and keeping all your projects in the same folder.
+This will make advanced steps easier.
 
 Update the following keys:
 
@@ -56,25 +68,44 @@ Update the following keys:
 ```
 
 ssh to your server in a terminal.
-Open a file from your project, save it. The status bar should show SFTP uploading the file to your server. You now have a working setup. SFTP will automatically upload files on save. But if you modify files out of Sublime (eg git checkout, git pull), you will need to upload the whole folder: `SFTP: Upload Folder`
+Open a file from your project, save it.
+The status bar should show SFTP uploading the file to your server.
+You now have a working setup.
+SFTP will automatically upload files on save.
+But if you modify files out of Sublime (eg git checkout, git pull),
+you will need to upload the whole folder: `SFTP: Upload Folder`
 
-Don't forget to buy an SFTP license if you find this setup useful. (I'm not affiliated in any way with SFTP plugin)
+Don't forget to buy an SFTP license if you find this setup useful.
+(I'm not affiliated in any way with SFTP plugin)
 
+[global gitignore]: https://stackoverflow.com/a/7335487/3561471
 
 # Adding rsync
 
-Uploading the whole folder is often a bit slow. Using `rsync` will be faster, it only pushes the changed files. SFTP should switch to use `rsync` at some point, but in the meantime, I use the following command.
-`rsync --verbose -rd --del --exclude='.git/' --filter=':- .gitignore'  . "server:\~/github/YOUR_PROJECT" &`
-Note that this command is _aggressive_: `--del` means that files on the server but not on your laptop will be deleted, unless they are in the `.gitignore`.
-The `--del` flag is useful if you rename a file locally. ST will upload the new version but won't remove the old one. Having `rsync --del` running from time to time allows to clean up this.
-Feel free to remove it if you have important files in your server project folder, that you don't want to risk to lose.
+Uploading the whole folder is often a bit slow.
+Using `rsync` will be faster,
+it only pushes the changed files.
+SFTP should switch to use `rsync` at some point,
+but in the meantime,
+I use the following command:
+`rsync --verbose -rd --del --exclude='.git/' --filter=':- .gitignore'`
+Note that this command is _aggressive_,
+`--del` means that files on the server but not on your laptop will be deleted,
+unless they are in the `.gitignore`.
+The `--del` flag is useful if you rename a file locally.
+SFTP will upload the new version but won't remove the old one.
+Having `rsync --del` running from time to time allows to clean up this.
+Feel free to remove it
+if you have important files in your server project folder,
+that you don't want to risk to lose.
 
 I added this to my `~/.zshrc`
 
 ```sh
 function rsync_git() {
     if [[ ! -d $PWD/.git ]]; then
-        echo "Current dir $PWD isn't a valid git dir. Please move to the root of a git dir."
+        echo "Current dir $PWD isn't a valid git dir.
+        Please move to the root of a git dir."
         return;
     fi
 
@@ -90,35 +121,50 @@ function rsync_git() {
 export -f rsync_git
 ```
 
-This allows me to run `rsync_git` when I'm at the root of my repo to upload the whole folder to my server.
-Since I want to have the code on my server to be always a mirror of the code on my laptop, I added git hooks to automatically run `rsync_git` when I checkout a branch:
+This allows me to run `rsync_git`
+when I'm at the root of my repo
+to upload the whole folder to my server.
+Since I want to have the code on my server
+to be always a mirror of the code on my laptop,
+I added git hooks to automatically run `rsync_git` when I checkout a branch:
 
 ```sh
 echo "source ~/.zshrc; rsync_git" > .git/post-checkout
 ```
 
-Note that it still takes a few seconds to run so if you start a job on your server just after pulling you may end up running code from the old branch.
+Note that it still takes a few seconds to run
+so if you start a job on your server just after pulling,
+you may end up running code from the old branch.
 
 
 # rmate for editing
 
-Running `rmate README.md` from your server will open the file on your laptop for editing.
-This is great for editing files from your server that aren't part of your project.
-I recommend closing the file in ST as soon as you're done editing, otherwise it's easy to end up with several tabs of ST editing the same remote file.
+Running `rmate README.md` from your server
+will open the file on your laptop for editing.
+This is great for editing files from your server
+that aren't part of your project.
+I recommend closing the file in ST as soon as you're done editing,
+otherwise it's easy to end up with several tabs of ST
+editing the same remote file.
 
-The install instructions can be found over on [RemoteSubl package website](https://github.com/randy3k/RemoteSubl#installation).
+The install instructions can be found over on [RemoteSubl][] package website.
 Mainly you need to install RemoteSubl package from PackageControl,
-install `rmate` on your server, add `RemoteForward` line to your `~/.ssh/config`:
+install `rmate` on your server,
+add `RemoteForward` line to your `~/.ssh/config`:
 
 ```
 Host server
-  ... # same as before
+  ...
+  # same as before
   RemoteForward 52698 localhost:52698
 ```
 
+[RemoteSubl]: https://github.com/randy3k/RemoteSubl#installation
+
 # Read long command output in Sublime
 
-Sometimes I'm running command with a long output and I want to read them more comfortably in ST rather than in a terminal.
+Sometimes I'm running command with a long output
+and I want to read them more comfortably in ST rather than in a terminal.
 
 Here is the function I'm using:
 

--- a/docs/guide/setup-examples/remote_dev.md
+++ b/docs/guide/setup-examples/remote_dev.md
@@ -1,0 +1,145 @@
+This steps should help working remotely with Sublime Text.
+They are meant to be incremental, just setting up SFTP will go a long way.
+
+
+# My workflow
+
+I have all my code on my laptop, edit locally and automatically push the files to my server.
+I never edit "tracked" files on the server directly.
+I sometimes modify untracked files on the server using `rmate` (see below).
+
+
+# SSH config
+
+Create a `~/.ssh/config` file, which allows reusing existing connection.
+This mean that you will have to authenticate only once.
+
+```
+Host server
+  Hostname SERVER_ADRESS
+  User MY_USERNAME
+  IdentityFile YOUR_KEY eg: ~/.ssh/id_rsa
+  AddKeysToAgent yes
+  UseKeychain yes
+  ControlPath ~/.ssh/ssh-%r@%h:%p
+  ControlMaster auto
+  ServerAliveInterval 240
+  Port 22
+```
+
+Check that it works by running "ssh server" in a terminal.
+Then in a second one. The second terminal shouldn't ask for credentials. 
+This will also allow Sublime to connect to your server without asking for credentials.
+
+# SFTP setup
+
+SFTP is a Sublime Text package that will allow you to keep in sync files on your laptop and on a server.
+
+Install https://packagecontrol.io/packages/SFTP
+Open your project in ST.
+From command palette: `SFTP: Setup Server`
+This will create a `sftp-config.json` at the root of your project. (You may want to add `sftp-config.json` to your [global gitignore](https://stackoverflow.com/a/7335487/3561471)).
+I recommend having the same project folder names on your server and on your laptop and keeping all your projects in the same folder. This will make advanced steps easier.
+
+Update the following keys:
+
+```json
+    // sftp, ftp or ftps
+    "type": "sftp",
+
+    "save_before_upload": true,
+    "upload_on_save": true,
+
+    "host": "server",
+    "user": "USER",
+    // Use full paths here, SFTP doesn't handle shortcuts like ~ or $HOME.
+    "remote_path": "/home/USER/github/YOUR_PROJECT",
+    "sftp_flags": ["-F", "/home/USER/.ssh/config"],
+```
+
+ssh to your server in a terminal.
+Open a file from your project, save it. The status bar should show SFTP uploading the file to your server. You now have a working setup. SFTP will automatically upload files on save. But if you modify files out of Sublime (eg git checkout, git pull), you will need to upload the whole folder: `SFTP: Upload Folder`
+
+Don't forget to buy an SFTP license if you find this setup useful. (I'm not affiliated in any way with SFTP plugin)
+
+
+# Adding rsync
+
+Uploading the whole folder is often a bit slow. Using `rsync` will be faster, it only pushes the changed files. SFTP should switch to use `rsync` at some point, but in the meantime, I use the following command.
+`rsync --verbose -rd --del --exclude='.git/' --filter=':- .gitignore'  . "server:\~/github/YOUR_PROJECT" &`
+Note that this command is _aggressive_: `--del` means that files on the server but not on your laptop will be deleted, unless they are in the `.gitignore`.
+The `--del` flag is useful if you rename a file locally. ST will upload the new version but won't remove the old one. Having `rsync --del` running from time to time allows to clean up this.
+Feel free to remove it if you have important files in your server project folder, that you don't want to risk to lose.
+
+I added this to my `~/.zshrc`
+
+```sh
+function rsync_git() {
+    if [[ ! -d $PWD/.git ]]; then
+        echo "Current dir $PWD isn't a valid git dir. Please move to the root of a git dir."
+        return;
+    fi
+
+    target=${1:-server:\~/github}
+    repo=${2:-${PWD##*/}}
+    # Async is important to not block git checkout
+    echo "Async rsync of git repo $repo to $target/$repo ..."
+
+    rsync --verbose -rd --del --exclude='.git/' --filter=':- .gitignore' \
+        . "$target/$repo" &
+}
+
+export -f rsync_git
+```
+
+This allows me to run `rsync_git` when I'm at the root of my repo to upload the whole folder to my server.
+Since I want to have the code on my server to be always a mirror of the code on my laptop, I added git hooks to automatically run `rsync_git` when I checkout a branch:
+
+```sh
+echo "source ~/.zshrc; rsync_git" > .git/post-checkout
+```
+
+Note that it still takes a few seconds to run so if you start a job on your server just after pulling you may end up running code from the old branch.
+
+
+# rmate for editing
+
+Running `rmate README.md` from your server will open the file on your laptop for editing.
+This is great for editing files from your server that aren't part of your project.
+I recommend closing the file in ST as soon as you're done editing, otherwise it's easy to end up with several tabs of ST editing the same remote file.
+
+The install instructions can be found over on [RemoteSubl package website](https://github.com/randy3k/RemoteSubl#installation).
+Mainly you need to install RemoteSubl package from PackageControl,
+install `rmate` on your server, add `RemoteForward` line to your `~/.ssh/config`:
+
+```
+Host server
+  ... # same as before
+  RemoteForward 52698 localhost:52698
+```
+
+# Read long command output in Sublime
+
+Sometimes I'm running command with a long output and I want to read them more comfortably in ST rather than in a terminal.
+
+Here is the function I'm using:
+
+```sh
+function subl() {
+    if (( $# > 0)); then
+        $HOME/bin/rmate "$@"
+        return;
+    fi
+
+    SUFFIX=${1:-.log}
+    tmpfile=`mktemp --suffix $SUFFIX`
+    echo "Stdout redirected to '$tmpfile'."
+    cat - > $tmpfile
+    echo "Opening '$tmpfile' on client."
+    $HOME/bin/rmate $tmpfile
+}
+export -f subl
+```
+
+Then I do: `python script.py --verbose | subl` from my server.
+Note than I can also do `subl script.py`.

--- a/docs/guide/setup-examples/remote_dev.md
+++ b/docs/guide/setup-examples/remote_dev.md
@@ -1,13 +1,11 @@
 This steps should help working remotely with Sublime Text.
 They are meant to be incremental, just setting up SFTP will go a long way.
 
-
 # My workflow
 
-I have all my code on my laptop, edit locally and automatically push the files to my server.
+I have all my code on my laptop (a Mac), edit locally and automatically push the files to my server (a Linux machine).
 I never edit "tracked" files on the server directly.
-I sometimes modify untracked files on the server using `rmate` (see below).
-
+I sometimes modify untracked files or config files on the server using `rmate` (see below).
 
 # SSH config
 

--- a/docs/guide/setup-examples/remote_dev.md
+++ b/docs/guide/setup-examples/remote_dev.md
@@ -1,48 +1,62 @@
-This steps should help working remotely with Sublime Text.
-They are meant to be incremental,
+---
+title: How to use Sublime for remote development
+---
+
+This guide should help working remotely with Sublime Text.
+The steps are meant to be incremental,
 just setting up SFTP will go a long way.
 
-# My workflow
+This guide will help you if
 
-I have all my code on my laptop (a Mac),
-edit locally and automatically push the files to my server (a Linux machine).
-I never edit "tracked" files on the server directly.
-I sometimes modify untracked files
-or config files on the server using `rmate` (see below).
+- you have all your code on your laptop
+- you want to edit your code locally in ST
+  and automatically push the changes to the server
+- you sometimes edit untracked files or config files on the server
 
-# SSH config
+
+## SSH config
 
 Create a `~/.ssh/config` file,
 which allows reusing existing connection.
 This mean that you will have to authenticate only once.
+In this example the server is simply named "my_server"
 
 ```
-Host server
+Host my_server
   Hostname SERVER_ADRESS
   User MY_USERNAME
   IdentityFile YOUR_KEY eg: ~/.ssh/id_rsa
   AddKeysToAgent yes
-  UseKeychain yes
-  ControlPath ~/.ssh/ssh-%r@%h:%p
-  ControlMaster auto
-  ServerAliveInterval 240
-  Port 22
 ```
 
-Check that it works by running "ssh server" in a terminal.
+Check that it works by running "ssh my_server" in a terminal.
 Then in a second one.
 The second terminal shouldn't ask for credentials.
 
 This will also allow Sublime to connect to your server
 without asking for credentials.
 
-# SFTP setup
+SFTP doesn't support two-auth authentication.
+If your server requires it,
+add the following lines to your ssh config
+to allow Sublime to reuse a connection opened in the terminal.
 
-SFTP is a Sublime Text package that will allow you to keep in sync files
+```
+  ControlPath ~/.ssh/ssh-%r@%h:%p
+  ControlMaster auto
+  ControlPersist 600
+```
+
+
+## SFTP setup
+
+SFTP is a commercial Sublime Text package
+that will allow you to keep in sync files
 on your laptop and on a server.
 
-Install https://packagecontrol.io/packages/SFTP
-Open your project in ST.
+Install [SFTP][] from Package Control. 
+(See [Installing Packages][] for details).
+Open your project in ST. 
 From command palette: **SFTP: Setup Server**
 This will create a `sftp-config.json` at the root of your project.
 (You may want to add `sftp-config.json` to your [global gitignore][].
@@ -60,7 +74,7 @@ Update the following keys:
     "save_before_upload": true,
     "upload_on_save": true,
 
-    "host": "server",
+    "host": "my_server",
     "user": "USER",
     // Use full paths here, SFTP doesn't handle shortcuts like ~ or $HOME.
     "remote_path": "/home/USER/github/YOUR_PROJECT",
@@ -75,31 +89,34 @@ SFTP will automatically upload files on save.
 But if you modify files out of Sublime (eg git checkout, git pull),
 you will need to upload the whole folder: `SFTP: Upload Folder`
 
-Don't forget to buy an SFTP license if you find this setup useful.
-(I'm not affiliated in any way with SFTP plugin)
-
+[Installing Packages]: https://docs.sublimetext.io/guide/extensibility/packages.html#installing-packages
+[SFTP]: https://packagecontrol.io/packages/SFTP
 [global gitignore]: https://stackoverflow.com/a/7335487/3561471
 
-# Adding rsync
+
+## Adding rsync
 
 Uploading the whole folder is often a bit slow.
 Using `rsync` will be faster,
 it only pushes the changed files.
 SFTP should switch to use `rsync` at some point,
 but in the meantime,
-I use the following command:
-`rsync --verbose -rd --del --exclude='.git/' --filter=':- .gitignore'`
-Note that this command is _aggressive_,
-`--del` means that files on the server but not on your laptop will be deleted,
-unless they are in the `.gitignore`.
-The `--del` flag is useful if you rename a file locally.
-SFTP will upload the new version but won't remove the old one.
-Having `rsync --del` running from time to time allows to clean up this.
-Feel free to remove it
-if you have important files in your server project folder,
-that you don't want to risk to lose.
+you can use the following command:
+```sh
+rsync --verbose -rd --exclude='.git/' --filter=':- .gitignore'
+```
 
-I added this to my `~/.zshrc`
+Files ignored by `.gitignore` won't be transfered.
+Note that this command is _safe_,
+it will only add files and never remove files.
+This can be an issue if you renamed a file locally
+because `rsync` will keep a file with the old name on the server.
+You can add the `--del` flag to automatically remove files on the remote 
+that don't exist locally.
+But be careful to keep important build artifacts, logs, profile reports
+in a dedicated folder present in your `.gitignore`. 
+
+Add this to your `~/.zshrc`.
 
 ```sh
 function rsync_git() {
@@ -114,19 +131,19 @@ function rsync_git() {
     # Async is important to not block git checkout
     echo "Async rsync of git repo $repo to $target/$repo ..."
 
-    rsync --verbose -rd --del --exclude='.git/' --filter=':- .gitignore' \
+    rsync --verbose -rd --exclude='.git/' --filter=':- .gitignore' \
         . "$target/$repo" &
 }
 
 export -f rsync_git
 ```
 
-This allows me to run `rsync_git`
-when I'm at the root of my repo
-to upload the whole folder to my server.
-Since I want to have the code on my server
-to be always a mirror of the code on my laptop,
-I added git hooks to automatically run `rsync_git` when I checkout a branch:
+With this you can run `rsync_git`
+when you're at the root of the repo
+to upload the whole folder to your server.
+
+To keep the remote code always a mirror of the code on your laptop,
+you want to automatically run `rsync_git` when you checkout a branch:
 
 ```sh
 echo "source ~/.zshrc; rsync_git" > .git/post-checkout
@@ -137,15 +154,12 @@ so if you start a job on your server just after pulling,
 you may end up running code from the old branch.
 
 
-# rmate for editing
+## rmate for editing
 
 Running `rmate README.md` from your server
 will open the file on your laptop for editing.
 This is great for editing files from your server
 that aren't part of your project.
-I recommend closing the file in ST as soon as you're done editing,
-otherwise it's easy to end up with several tabs of ST
-editing the same remote file.
 
 The install instructions can be found over on [RemoteSubl][] package website.
 Mainly you need to install RemoteSubl package from PackageControl,
@@ -154,19 +168,18 @@ add `RemoteForward` line to your `~/.ssh/config`:
 
 ```
 Host server
-  ...
-  # same as before
+  ... # same as before
   RemoteForward 52698 localhost:52698
 ```
 
 [RemoteSubl]: https://github.com/randy3k/RemoteSubl#installation
 
-# Read long command output in Sublime
 
-Sometimes I'm running command with a long output
-and I want to read them more comfortably in ST rather than in a terminal.
+## Read long command output in Sublime
 
-Here is the function I'm using:
+To read the output of some verbose command,
+comfortably in ST rather than in a terminal,
+you can use the following function:
 
 ```sh
 function subl() {
@@ -185,5 +198,7 @@ function subl() {
 export -f subl
 ```
 
-Then I do: `python script.py --verbose | subl` from my server.
-Note than I can also do `subl script.py`.
+You can then run `python script.py --verbose | subl` from your server
+and read the results from ST.
+Note that the function can also be used as an alias to `rmate`:
+`subl script.py`.

--- a/docs/guide/setup-examples/remote_dev.md
+++ b/docs/guide/setup-examples/remote_dev.md
@@ -9,6 +9,7 @@ just setting up SFTP will go a long way.
 This guide will help you if
 
 - you have all your code on your laptop
+- you have SSH access to your server
 - you want to edit your code locally in ST
   and automatically push the changes to the server
 - you sometimes edit untracked files or config files on the server
@@ -36,7 +37,7 @@ The second terminal shouldn't ask for credentials.
 This will also allow Sublime to connect to your server
 without asking for credentials.
 
-SFTP doesn't support two-auth authentication.
+SFTP doesn't support two-factor authentication.
 If your server requires it,
 add the following lines to your ssh config
 to allow Sublime to reuse a connection opened in the terminal.
@@ -50,14 +51,15 @@ to allow Sublime to reuse a connection opened in the terminal.
 
 ## SFTP setup
 
-SFTP is a commercial Sublime Text package
+SFTP is a commercial Sublime Text package,
 that will allow you to keep in sync files
 on your laptop and on a server.
 
-Install [SFTP][] from Package Control. 
-(See [Installing Packages][] for details).
-Open your project in ST. 
-From command palette: **SFTP: Setup Server**
+- Install [SFTP][] from Package Control
+(See [Installing Packages][] for details)
+- Open your project in ST. 
+- From command palette: **SFTP: Setup Server**
+
 This will create a `sftp-config.json` at the root of your project.
 (You may want to add `sftp-config.json` to your [global gitignore][].
 I recommend having the same project folder names


### PR DESCRIPTION
The idea is to collect a bunch of resources `How to use Sublime for doing X`.
Sublime generally need some setup when you start working seriously with one language/programming stack.
Having those guides will help new ST users to get started with a new project.

This PR adds:
* [How to use Sublime for remote devlopment](https://gist.github.com/gwenzek/2e5ea19594335ad3b79c0fb3d63e3223) which I authored.
* [How to use Sublime with Julia](https://github.com/PetrKryslUCSD/HowToUseJuliaWithSublimeText3) from @PetrKryslUCSD.

Let's discuss what's would be the best place to put those guides :-)

I cleaned up Julia guide to focus on Julia exclusively. I'm not sure about some the Zeal configuration files it seems to be outdated.
Pages mentionning plugins may tend to be obsolete faster than the rest of the documentation because the plugins API tend to evolve faster than core ST.
So maybe those pages should have a proeminent timestamp or versions of the mentioned plugins.

What are you thoughts on this ?

EDIT: maybe there should be some guidelines for authors of those guides. Things I tried to apply to myself:

* Make the guide incremental:
  Don't start by asking the user to install 5 plugins and then explain how they are used. Start minimalist and add features/plugins progressively.
* Explicit your workflow from the start, so that people can see if they something they want to use.
* Explicit the OS used, ST is cross-platform, but some plugins need extra configuration for specific OS.
* Encourage the use of command palette instead of menus.

It would also be helpful if we could assume the readers know about Package Contrrol, Command Palette, ... 