### PR TITLE
Various issues fixed from the old repo

### DIFF
--- a/docs/guide/extensibility/command_palette.md
+++ b/docs/guide/extensibility/command_palette.md
@@ -14,7 +14,7 @@ The *command palette* bound to <Key k="ctrl+shift+p" /> is an interactive list
 whose purpose is to execute commands. The command palette is fed by
 entries in `.sublime-commands` files. Usually, commands that don't
 warrant creating a key binding of their own are good candidates for
-inclusion in a `.sublime- commands` files.
+inclusion in a `.sublime-commands` files.
 
 By default, the command palette includes many useful commands, and
 provides convenient access to individual settings as well as settings

--- a/docs/guide/extensibility/plugins/README.md
+++ b/docs/guide/extensibility/plugins/README.md
@@ -43,7 +43,7 @@ directly under `Packages` you might get confusing results.
 
 Let's write a "Hello, World!" plugin for Sublime Text:
 
-1. Select **Tools | New Plugin...** in the menu.
+1. Select **Tools | Developer | New Plugin...** in the menu.
 1. Save to `Packages/User/hello_world.py`.
 
 You've just written your first plugin! Let's put it to use:

--- a/docs/guide/extensibility/snippets.md
+++ b/docs/guide/extensibility/snippets.md
@@ -99,8 +99,6 @@ Snippets have access to contextual information in the form of
 environment variables. The values of the variables listed below are set
 automatically by Sublime Text.
 
-You can also add your own variables to provide extra information. These
-custom variables are defined in `.sublime-options` files.
 
 |      Variable        |                           Description                                 |
 | -------------------- | --------------------------------------------------------------------- |

--- a/docs/reference/comments.md
+++ b/docs/reference/comments.md
@@ -43,7 +43,6 @@ of a comment metadata file:
    <string>source.python</string>
    <key>settings</key>
    <dict>
-      <string></string>
       <key>shellVariables</key>
       <array>
          <dict>

--- a/docs/reference/menus.md
+++ b/docs/reference/menus.md
@@ -97,6 +97,12 @@ each menu item must define either
 
   Refer to the [main documentation][item-ids] on how this works.
 
+`platform`
+: The platform name for which the menu entry should be made
+  visible. Valid values are `OSX`, `Linux` & `Windows`.
+  It also supports negation in the form `!OSX` which means
+  to show the menu entry for all platforms except `OSX`.
+
 [menu-guide]: /guide/customization/menus.md
 [Menu Separator]: /guide/customization/menus.md#separators
 [item-ids]: /guide/customization/menus.md#item-ids


### PR DESCRIPTION
This PR fixes the following issues raised on the old [undocs](https://github.com/guillermooo/sublime-undocs) repo.
1. [#266](https://github.com/guillermooo/sublime-undocs/issues/266) where the presence of an extra `<string></string>` was throwing an `expected element key` error.
2. [#247](https://github.com/guillermooo/sublime-undocs/issues/247) where the menu entry for `New Plugin...` was wrongly stated.
3. [#246](https://github.com/guillermooo/sublime-undocs/issues/246) where the `platform` key was not documented in the reference section for menus.
4. [#226](https://github.com/guillermooo/sublime-undocs/issues/226) which discusses about the hypothetical `.sublime-options` file. That paragraph is now removed.