### PR TITLE
fix: incorrect image path for menu gif

### DIFF
--- a/docs/guide/customization/menus.md
+++ b/docs/guide/customization/menus.md
@@ -92,7 +92,7 @@ in the status bar:
 - **Indentation**
 - **Syntax**
 
-![Demonstration of a status bar menu.](images/statusbar_menu.gif)
+![Demonstration of a status bar menu.](./images/statusbar_menu.gif)
 
 ### Menu Items
 


### PR DESCRIPTION
Minor fix for the gif image on https://docs.sublimetext.io/guide/customization/menus.html#available-menus