### PR TITLE
Add command: chain

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -52,6 +52,13 @@ Runs a build system.
 
 - **variant** (String): Optional. The name of the variant to be run.
 
+### `chain`
+
+Chains multiple commands to execute together. Below are the parameters
+accepted by the this command.
+
+- **commands** [{String: String}]: The chain of commands that will be executed.
+
 ### `clear_bookmarks`
 
 If no **name** argument, or the **name** "bookmarks" is specified, it


### PR DESCRIPTION
Added the documentation for the built-in `chain` command release in ST4. 

Fixes #65 