### PR TITLE
Fix Typo in index.md Where Usage is Incorrectly Spelled

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ features:
   - icon: ⚡️
     title: The Guide
     link: /guide/
-    details: Includes basic information on Sublime Text covers its usag and how it can be customized.
+    details: Includes basic information on Sublime Text covers its usage and how it can be customized.
   - icon: 🎉
     title: The Reference
     link: /reference/


### PR DESCRIPTION
There is a small typo on the landing page under Features / The Guide where "usage" is incorrectly spelled as "usag".

No other content or structural changes were made.