### PR TITLE
Add "Accumulating Inputs from a List" example

### DIFF
--- a/docs/guide/extensibility/plugins/input_handlers/code/Input Handlers.sublime-commands
+++ b/docs/guide/extensibility/plugins/input_handlers/code/Input Handlers.sublime-commands
@@ -2,4 +2,5 @@
     { "caption": "Simple Command", "command": "simple" },
     { "caption": "Insert Html Entity", "command": "insert_html_entity" },
     { "caption": "Multiply", "command": "multiply" },
+    { "caption": "Accumulate", "command": "accumulate" },
 ]

--- a/docs/guide/extensibility/plugins/input_handlers/code/accumulate.py
+++ b/docs/guide/extensibility/plugins/input_handlers/code/accumulate.py
@@ -1,0 +1,51 @@
+import sublime_plugin
+
+
+class ItemsInputHandler(sublime_plugin.ListInputHandler):
+    def __init__(self, choices, accumulated=None, selected_index=0):
+        self.choices = choices
+        self.accumulated = accumulated or []
+        self.selected_index = selected_index
+
+        self.alt_pressed = False
+        self.selected = None
+
+    def want_event(self):
+        # Declare that we want to receive the `event` argument.
+        return True
+
+    def validate(self, _value, _event):
+        # We must override this method because we define `want_event`.
+        # https://github.com/sublimehq/sublime_text/issues/6258
+        return True
+
+    def list_items(self):
+        # Each selectable item represents
+        # all accumulated items plus the new item as a list.
+        return (
+            [(item, self.accumulated + [item]) for item in self.choices],
+            self.selected_index,
+        )
+
+    def confirm(self, value, event):
+        # Record that the alt key was pressed when confirming
+        # so that we can return a follow-up input handler
+        # in `next_input`.
+        self.alt_pressed = event["modifier_keys"].get("alt", False)
+        self.selected = value
+
+    def next_input(self, _args):
+        if self.alt_pressed:
+            selected_index = self.choices.index(self.selected[-1])
+            return ItemsInputHandler(self.choices, self.selected, selected_index)
+        return None
+
+
+class AccumulateCommand(sublime_plugin.WindowCommand):
+    def input(self, args):
+        if "items" not in args:
+            choices = "a b c d e".split(" ")
+            return ItemsInputHandler(choices=choices)
+
+    def run(self, items):
+        self.window.run_command('insert', {'characters': " ".join(items)})

--- a/docs/guide/extensibility/plugins/input_handlers/images/accumulate.mp4
+++ b/docs/guide/extensibility/plugins/input_handlers/images/accumulate.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:369c64b5371943e299f4d4e6efed8775fa4c7e89dba75e1fb0747ad4b5daadab
+size 293113

--- a/docs/guide/extensibility/plugins/input_handlers/index.md
+++ b/docs/guide/extensibility/plugins/input_handlers/index.md
@@ -323,7 +323,7 @@ Try for yourself!
 
 The final code examples presented on this page
 [are included in the source git repository][code].
-You can download a [zip][] of it (via [DownGit][])
+You can download a [zipball][] of it (via [DownGit][])
 and extract it into your Packages folder
 to experiment with them.
 


### PR DESCRIPTION
Provide and discuss an example for accumulating multiple input values in a single list, utilizing the 2-tuple return value of `list_items`, event info when specifying `want_event`, and a sort of self-overriding `next_input` return value.

I initially made this during a discussion on Discord: https://discord.com/channels/280102180189634562/280157067396775936/1192776891183140955

Opening a PR for an initial review. I'll likely merge this tomorrow evening.