### PR TITLE
docs:  fix typo and newly discovered keymap context condition...

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -190,7 +190,7 @@ Runs an external process asynchronously. On Windows, GUIs are supressed.
 
 `exec` is the default command used by build systems, thus it provides
 similar functionality. However, a few options in build systems are taken
-care of by Sublime Text internally so they list below only contains
+care of by Sublime Text internally so the list below only contains
 parameters accepted by this command.
 
 - **cmd** [(String)]

--- a/docs/reference/key_bindings.md
+++ b/docs/reference/key_bindings.md
@@ -118,9 +118,15 @@ provided by Sublime Text itself.
   if the autocomplete list
   is visible.
 
+`eol_select`
+: Selector to match scope name at end of current line
+
+`following_text`
+: Test against the selected text and the text
+  following it until the end of the line.
+
 `group_has_multiselect`
 : Returns `true` if group has multi-select
-  (in default key bindings, alters behavior of Alt-0 through Alt-9)
 
 `has_next_field`
 : Returns `true`
@@ -136,35 +142,56 @@ provided by Sublime Text itself.
 : Returns `true` if caret(s) is (are) in a comment that
   starts with `/**`
 
+`is_recording_macro`
+: Is user currently recording a macro?
+
 `last_command`
 : Returns the name of the last command run.
 
+`last_modifying_command`
+: Name of last command run that modified a buffer
+
 `num_selections`
 : Returns the number of selections.
+
+`overlay_has_focus`
+: Returns `true` if any overlay has focus.
 
 `overlay_visible`
 : Returns `true`
   if any overlay is visible.
 
-`overlay_has_focus`
-: Returns `true` if any overlay has focus.
+`panel`
+: Returns `true`
+  if the panel given as `operand`
+  is visible.
+
+`panel_has_focus`
+: Returns `true`
+  if a panel
+  has input focus.
 
 `panel_visible`
 : Returns `true`
   if any panel is visible.
 
-`following_text`
-: Test against the selected text and the text
-  following it until the end of the line.
+`popup_visible`
+: Is a popup currently being displayed?
 
 `preceding_text`
 : Test against the text on the line up to and
   including the selection.
 
+`read_only`
+: Is buffer in read-only state?
+
 `selection_empty`
 : Returns `true`
   if the selection
   is an empty region.
+
+`selector`
+: Name of scope for current selection.
 
 `setting.x`
 : Returns the value of the `x` setting.
@@ -173,19 +200,6 @@ provided by Sublime Text itself.
 `text`
 : Restricts the test
   to the selected text.
-
-`selector`
-: Returns the name of the current scope.
-
-`panel_has_focus`
-: Returns `true`
-  if a panel
-  has input focus.
-
-`panel`
-: Returns `true`
-  if the panel given as `operand`
-  is visible.
 
   <!-- Cause upper text to become a paragraph and fix a spacing bug. -->
 

--- a/docs/reference/key_bindings.md
+++ b/docs/reference/key_bindings.md
@@ -118,6 +118,10 @@ provided by Sublime Text itself.
   if the autocomplete list
   is visible.
 
+`group_has_multiselect`
+: Returns `true` if group has multi-select
+  (in default key bindings, alters behavior of Alt-0 through Alt-9)
+
 `has_next_field`
 : Returns `true`
   if a next snippet field

--- a/docs/reference/key_bindings.md
+++ b/docs/reference/key_bindings.md
@@ -128,6 +128,10 @@ provided by Sublime Text itself.
   if a previous snippet field
   is available.
 
+`is_javadoc`
+: Returns `true` if caret(s) is (are) in a comment that
+  starts with `/**`
+
 `last_command`
 : Returns the name of the last command run.
 

--- a/docs/reference/key_bindings.md
+++ b/docs/reference/key_bindings.md
@@ -146,6 +146,9 @@ provided by Sublime Text itself.
 : Returns `true`
   if any overlay is visible.
 
+`overlay_has_focus`
+: Returns `true` if any overlay has focus.
+
 `panel_visible`
 : Returns `true`
   if any panel is visible.


### PR DESCRIPTION
...for key bindings:  `is_javadoc`.  I found it lurking in the `Default (Windows).sublime-keymap` file with the `enter` key. It returns `true` when the caret(s) is (are) in a comment that starts with `/**`.  I tested it in a `.c` and `.css` file and it works in both places.  I added in in alphabetical order, which looked like the originally-intended order of the "Context Keys" list.

Also added context condition `group_has_multiselect`, also found in `Default (Windows).sublime-keymap`.

Als added `overlay_has_focus` key context condition, .also found in Default (Windows).sublime-keymap (build 4192).