### PR TITLE
fix(menus.md):  fix link to command API...

### DIFF
--- a/docs/guide/customization/menus.md
+++ b/docs/guide/customization/menus.md
@@ -286,7 +286,7 @@ without arguments.
 Some of these methods also have an influence on the Command Palette.
 
 ::: info See Also 
-[Official API Documentation on the Command interface](https://www.sublimetext.com/docs/api_reference.html#sublime_plugin.ApplicationCommand)
+[Official API Documentation on the Command interface](https://www.sublimetext.com/docs/api_reference.html#sublime_plugin.Command)
 :::
 
 ## Context Menus in the Side Bar


### PR DESCRIPTION
...because the link previously there is not where the `is_enabled`, `is_visible`, `is_checked` and `description` methods are actually documented.  The page was correct, but the anchor name is different.  This PR fixes that.