### PR TITLE
Stop using the timeout label

### DIFF
--- a/docs/reference/package-control/reviewing.md
+++ b/docs/reference/package-control/reviewing.md
@@ -37,7 +37,7 @@ the maintainer is pinged in the PR
 and the `stale` label is assigned.
 
 After another two weeks without a response,
-close the PR and assign the `timeout` label.
+close the PR.
 
 If the author does respond,
 remove the `stale` label


### PR DESCRIPTION
It's not done consistently, and it's not necessary: filtering by closed, unmerged, stale pr's gives the same info. I'm checking the history of pr's and adjusting any that I see with incorrect label. Although I must say we never look back on these labels very much.

And, eh, maybe I can get some level of access to this repo so I can maintain "my own" documentation in here more easily? @FichteFoll 