### PR TITLE
docs: fix Windows mouse shortcuts for multiple selections

### DIFF
--- a/docs/guide/usage/editing.md
+++ b/docs/guide/usage/editing.md
@@ -42,7 +42,8 @@ It's possible to add blocks of text to or remove them from the selection.
 | Description           | Shortcut                                    |
 | --------------------- | ------------------------------------------- |
 | Select Block          | <Key k="shift" /> + Right Mouse Button      |
-| Add to Selection      | <Key k="ctrl+shift" /> + Right Mouse Button |
+| Add to Selection      | <Key k="ctrl" /> + Left Mouse Button |
+| Add Block to Selection | <Key k="ctrl+shift" /> + Right Mouse Button |
 | Remove from Selection | <Key k="alt+shift" /> + Right Mouse Button  |
 
 **macOS**


### PR DESCRIPTION
- Add to Selection now correctly shows Ctrl+Left Mouse (fixes duplicate shortcut)
- Add Block to Selection remains Ctrl+Shift+Right Mouse

As reported in issue #144