### PR TITLE
docs: add revert_hunk and revert_modification commands

### DIFF
--- a/docs/guide/extensibility/commands.md
+++ b/docs/guide/extensibility/commands.md
@@ -32,21 +32,6 @@ view.run_command('insert_snippet', {"contents": "<$SELECTION>"})
 view.window().run_command("prompt_select_project")
 ```
 
-### Reverting Changes
-
-Sublime Text can revert changes even without a Git repository:
-
-```python
-view.run_command("revert_modification")  # Reverts modifications in current selection
-view.run_command("revert_hunk")           # Reverts current hunk (line-based)
-```
-
-
-These commands have a default key binding:  
-<Key k="ctrl+k" />, <Key k="ctrl+z" /> (Windows/Linux)  
-<Key k="super+k" />, <Key k="super+z" /> (Mac)
-
-
 ## From command line (CLI)
 
 Commands may be passed to Sublime Text directly from the command line

--- a/docs/guide/extensibility/commands.md
+++ b/docs/guide/extensibility/commands.md
@@ -32,6 +32,21 @@ view.run_command('insert_snippet', {"contents": "<$SELECTION>"})
 view.window().run_command("prompt_select_project")
 ```
 
+### Reverting Changes
+
+Sublime Text can revert changes even without a Git repository:
+
+```python
+view.run_command("revert_modification")  # Reverts modifications in current selection
+view.run_command("revert_hunk")           # Reverts current hunk (line-based)
+```
+
+
+These commands have a default key binding:  
+<Key k="ctrl+k" />, <Key k="ctrl+z" /> (Windows/Linux)  
+<Key k="super+k" />, <Key k="super+z" /> (Mac)
+
+
 ## From command line (CLI)
 
 Commands may be passed to Sublime Text directly from the command line

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -596,6 +596,14 @@ might be other places where this has been "changed".
 
 Undoes all unsaved changes to the file.
 
+### `revert_hunk`
+
+Reverts the current hunk (line-based changes). Works without a Git repository.
+
+### `revert_modification`
+
+Reverts modifications in the current selection. Works without a Git repository.
+
 ### `right_delete`
 
 Deletes the character right after the caret.


### PR DESCRIPTION
- Added both revert commands with descriptions
- Included keyboard shortcuts (Ctrl+K, Ctrl+Z and ⌘+K, ⌘+Z)
- Noted they work without Git repository

Fixes #143