### PR TITLE
docs(submitting):  add how to use pkg review tool

### DIFF
--- a/docs/guide/package-control/submitting.md
+++ b/docs/guide/package-control/submitting.md
@@ -156,6 +156,20 @@ st_package_reviewer  path/to/your/package
 This is also an excellent way to learn more about what is needed and
 wanted in new Sublime Text packages by the Package Control team.
 
+You can note the program's exit code to determine whether it would
+generate a "pass" or "fail" on your submission as a PR.  Exit code 0
+means "pass".
+
+Notes:
+
+```bash
+st_package_reviewer  --help
+```
+
+will show you its many options.
+
+You need at least Python v3.13 to run it.
+
 
 ## Submit a pull request
 

--- a/docs/guide/package-control/submitting.md
+++ b/docs/guide/package-control/submitting.md
@@ -128,6 +128,35 @@ Fork the [Package Control Channel][pcc]. Then:
   in the root directory.
 
 
+## Review your submission
+
+There is a command-line utility that can assist you by telling you
+what the software that reviews your Pull Request (PR) (via a GitHub
+`action`) will say before you submit it, giving you the chance to
+get it right the first time.
+
+How to get it:
+
+The same version that is used as the GitHub action can be installed
+on your local system like this:
+
+```bash
+pip install "git+https://github.com/kaste/st_package_reviewer.git"
+```
+
+The easiest way to use it is to simply `cd` to the directory where
+your package is and say:
+
+```bash
+st_package_reviewer  .
+# or
+st_package_reviewer  path/to/your/package
+```
+
+This is also an excellent way to learn more about what is needed and
+wanted in new Sublime Text packages by the Package Control team.
+
+
 ## Submit a pull request
 
 Now you're ready to push your changes and make a PR


### PR DESCRIPTION
Fixes:  #151 

This addresses the omission spelled out in #151, enabling package developers to do a better review of their own work before submitting new packages as PRs.